### PR TITLE
fix: resolve Homebrew 'No such file or directory - terminal-jarvis' error

### DIFF
--- a/.github/workflows/cd-multiplatform.yml
+++ b/.github/workflows/cd-multiplatform.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           name: binaries-${{ matrix.platform }}
           path: |
-            target/*/release/terminal-jarvis*
+            target/*/release/terminal-jarvis
             homebrew/release/*.tar.gz
           retention-days: 1
 
@@ -146,12 +146,12 @@ jobs:
           for platform_dir in artifacts/binaries-*; do
             platform=$(basename "$platform_dir" | sed 's/binaries-//')
             
-            # Find all binaries for this platform
-            find "$platform_dir" -name "terminal-jarvis*" -type f | while read binary; do
+            # Find all terminal-jarvis binaries (exclude debug directories and files)
+            find "$platform_dir" -name "terminal-jarvis" -type f -executable | while read binary; do
               # Determine architecture from path
               arch=$(echo "$binary" | grep -o '[^/]*-[^/]*-[^/]*' | head -1 | cut -d'-' -f1)
               
-              # Create platform-specific archive
+              # Create platform-specific archive with correct binary name
               archive_name="terminal-jarvis-${platform}-${arch}.tar.gz"
               tar -czf "release-assets/$archive_name" -C "$(dirname "$binary")" "$(basename "$binary")"
               echo "Created detailed archive: $archive_name"

--- a/homebrew/Formula/terminal-jarvis.rb
+++ b/homebrew/Formula/terminal-jarvis.rb
@@ -1,0 +1,28 @@
+# Documentation: https://docs.brew.sh/Formula-Cookbook
+#                https://rubydoc.brew.sh/Formula
+# Based on Federico Terzi's approach: https://federicoterzi.com/blog/how-to-publish-your-rust-project-on-homebrew/
+
+class TerminalJarvis < Formula
+  desc "A unified command center for AI coding tools"
+  homepage "https://github.com/BA-CalderonMorales/terminal-jarvis"
+  version "0.0.60"
+  license "MIT"
+
+  on_macos do
+    url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.60/terminal-jarvis-mac.tar.gz"
+    sha256 "1b531f95493211c322c13f81aef7bc47c60794db3eea72ab11119bdf3acd00d8"
+  end
+
+  on_linux do
+    url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.60/terminal-jarvis-linux.tar.gz"
+    sha256 "86b9374b464f5a0e65f0c484c160d394223e8a05af31e459bb4dc87e404ee06f"
+  end
+
+  def install
+    bin.install "terminal-jarvis"
+  end
+
+  test do
+    system "#{bin}/terminal-jarvis", "--version"
+  end
+end


### PR DESCRIPTION
## Problem

Users experiencing Homebrew installation failures with error:
```
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory - terminal-jarvis
```

When running:
```bash
brew install ba-calderonmorales/terminal-jarvis/terminal-jarvis
# or
brew reinstall terminal-jarvis
```

## Root Cause Analysis

Investigation revealed that architecture-specific archives (e.g., `terminal-jarvis-macos-aarch64.tar.gz`) contained debug directories instead of executable binaries:

**Problematic Archive Content:**
```bash
$ curl -sL https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.60/terminal-jarvis-macos-aarch64.tar.gz | tar -tz
terminal-jarvis.d  # ❌ Debug directory instead of binary
```

**Working Archive Content:**
```bash
$ curl -sL https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.60/terminal-jarvis-mac.tar.gz | tar -tz  
terminal-jarvis    # ✅ Correct executable binary
```

The issue originated from the GitHub Actions workflow uploading artifacts with pattern `target/*/release/terminal-jarvis*`, which included both binaries and debug directories.

## Solution

### 1. Fixed GitHub Actions Artifact Upload

**Before:**
```yaml
path: |
  target/*/release/terminal-jarvis*  # ❌ Includes debug dirs
  homebrew/release/*.tar.gz
```

**After:**
```yaml
path: |
  target/*/release/terminal-jarvis   # ✅ Executable binary only
  homebrew/release/*.tar.gz
```

### 2. Improved Archive Creation Logic

**Before:**
```bash
find "$platform_dir" -name "terminal-jarvis*" -type f | while read binary; do
```

**After:**
```bash
find "$platform_dir" -name "terminal-jarvis" -type f -executable | while read binary; do
```

This ensures only executable binaries are packaged, excluding debug directories and files.

### 3. Added Local Homebrew Formula for Testing

Created `homebrew/Formula/terminal-jarvis.rb` with verified checksums for working archives, enabling local testing before deployment.

## Testing Performed

### ✅ Local Tap Testing Protocol
```bash
# 1. Create test tap
mkdir -p /tmp/homebrew-test-tap/Formula
cp homebrew/Formula/terminal-jarvis.rb /tmp/homebrew-test-tap/Formula/
cd /tmp/homebrew-test-tap && git init && git add . && git commit -m "Test"

# 2. Add test tap and install
brew tap local/test /tmp/homebrew-test-tap
brew install local/test/terminal-jarvis

# 3. Verify functionality
terminal-jarvis --version  # ✅ terminal-jarvis 0.0.60
brew test local/test/terminal-jarvis  # ✅ Passed

# 4. Cleanup
brew uninstall terminal-jarvis && brew untap local/test
```

### ✅ Archive Content Verification
```bash
# Confirmed working archives contain correct binary
curl -sL https://github.com/.../terminal-jarvis-mac.tar.gz | tar -tz
# Output: terminal-jarvis ✅

curl -sL https://github.com/.../terminal-jarvis-linux.tar.gz | tar -tz  
# Output: terminal-jarvis ✅
```

### ✅ Checksum Validation
```bash
# Verified SHA256 checksums for working archives
curl -sL https://github.com/.../terminal-jarvis-mac.tar.gz | shasum -a 256
# 1b531f95493211c322c13f81aef7bc47c60794db3eea72ab11119bdf3acd00d8

curl -sL https://github.com/.../terminal-jarvis-linux.tar.gz | shasum -a 256  
# 86b9374b464f5a0e65f0c484c160d394223e8a05af31e459bb4dc87e404ee06f
```

## Impact

**Immediate:**
- ✅ Prevents future releases from having broken architecture-specific archives
- ✅ Ensures Homebrew Formula generation uses correct binaries
- ✅ Maintains compatibility with existing working archives (`terminal-jarvis-mac.tar.gz`, `terminal-jarvis-linux.tar.gz`)

**For Current v0.0.60:**
- Architecture-specific archives still broken (requires new release)
- Working archives remain functional
- Alternative install methods unaffected (`cargo install`, `npm install -g`)

## Workarounds for Current Issue

**Option 1: Wait for next release** (recommended)
- This fix will be included in future releases

**Option 2: Use alternative installation methods**
```bash
# Via Cargo
cargo install terminal-jarvis

# Via NPM  
npm install -g terminal-jarvis
```

**Option 3: Manual Homebrew Formula (advanced users)**
```bash
# Use working archives directly
brew install https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.60/terminal-jarvis-mac.tar.gz
```

## Files Modified

- `.github/workflows/cd-multiplatform.yml` - Fixed artifact upload and archive creation
- `homebrew/Formula/terminal-jarvis.rb` - Added local testing formula

## Verification Commands

```bash
# After next release, users can verify:
brew install ba-calderonmorales/terminal-jarvis/terminal-jarvis
terminal-jarvis --version
brew test ba-calderonmorales/terminal-jarvis/terminal-jarvis
```

This fix follows the established multi-platform build system architecture and maintains compatibility with all distribution channels (NPM, Crates.io, Homebrew).