### PR TITLE
docs: clarify macOS Rust requirement

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -63,10 +63,11 @@ terminal-jarvis --version
 
 ### macOS Prerequisites
 
-**Important**: macOS users must install Rust before using Terminal Jarvis.
+**Note**: The NPM package includes a precompiled macOS binary.
+Install Rust only if you plan to build from source or use the Cargo/Homebrew workflows.
 
 ```bash
-# 1. Install Rust via rustup
+# 1. (Optional) Install Rust via rustup
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # 2. Reload your shell environment


### PR DESCRIPTION
## Summary
- clarify macOS instructions: Rust is only needed for Cargo/Homebrew or building from source
- mark rustup step as optional

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- list`
- `cargo run -- --help`


------
https://chatgpt.com/codex/tasks/task_e_68b9827d7e648333a0ef1a7637554168