### PR TITLE
chore(release): prepare v0.0.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.77] - 2026-02-17
+
+### Fixed
+- **NPM Beta/Stable Workflows**: Rewrote both workflows as lightweight dist-tag managers
+  - Removed broken OTP-based publish flow incompatible with automation tokens
+  - Workflows now add dist-tags to already-published versions from the CD pipeline
+  - No Rust build, no npm publish, no 2FA required in these workflows
+  - Fixes: `npm install -g terminal-jarvis@beta` and `terminal-jarvis@stable` install paths
+
 ## [0.0.76] - 2026-02-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-jarvis"
-version = "0.0.76"
+version = "0.0.77"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-jarvis"
-version = "0.0.76"
+version = "0.0.77"
 edition = "2021"
 description = "A thin Rust wrapper that provides a unified interface for managing and running AI coding tools"
 authors = ["BA-CalderonMorales"]

--- a/homebrew/Formula/terminal-jarvis.rb
+++ b/homebrew/Formula/terminal-jarvis.rb
@@ -1,26 +1,26 @@
 class TerminalJarvis < Formula
   desc "A unified command center for AI coding tools"
   homepage "https://github.com/BA-CalderonMorales/terminal-jarvis"
-  version "0.0.76"
+  version "0.0.77"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.76/terminal-jarvis-mac.tar.gz"
+      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.77/terminal-jarvis-mac.tar.gz"
       sha256 "SKIP_CHECK"
     elsif Hardware::CPU.arm?
-      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.76/terminal-jarvis-mac.tar.gz"
+      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.77/terminal-jarvis-mac.tar.gz"
       sha256 "SKIP_CHECK"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.76/terminal-jarvis-linux.tar.gz"
+      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.77/terminal-jarvis-linux.tar.gz"
       sha256 "SKIP_CHECK"
     else
       # Fallback for other Linux architectures
-      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.76/terminal-jarvis-linux.tar.gz"
+      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.77/terminal-jarvis-linux.tar.gz"
       sha256 "SKIP_CHECK"
     end
   end

--- a/npm/terminal-jarvis/config/tools/aider.toml
+++ b/npm/terminal-jarvis/config/tools/aider.toml
@@ -37,6 +37,7 @@ verify_command = "aider --version"
 
 [tool.auth]
 env_vars = [
+    "OPENROUTER_API_KEY",
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
     "GEMINI_API_KEY",
@@ -45,6 +46,14 @@ env_vars = [
 setup_url = "https://aider.chat/docs/install.html#api-keys"
 browser_auth = false
 auth_instructions = "Set your preferred AI provider API key (OpenAI, Anthropic, Google, Azure, etc.)"
+auth_mode = "any"
+default_env_var = "OPENROUTER_API_KEY"
+providers = [
+    {name = "OpenRouter", env_var = "OPENROUTER_API_KEY", key_hint = "sk-or-*", setup_url = "https://openrouter.ai/keys"},
+    {name = "OpenAI", env_var = "OPENAI_API_KEY", key_hint = "sk-*", setup_url = "https://platform.openai.com/api-keys"},
+    {name = "Anthropic", env_var = "ANTHROPIC_API_KEY", key_hint = "sk-ant-*", setup_url = "https://console.anthropic.com/"},
+    {name = "Gemini", env_var = "GEMINI_API_KEY", key_hint = "AIza*", setup_url = "https://aistudio.google.com/app/apikey"},
+]
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/amp.toml
+++ b/npm/terminal-jarvis/config/tools/amp.toml
@@ -27,10 +27,17 @@ args = ["update", "-g", "@sourcegraph/amp"]
 verify_command = "amp --version"
 
 [tool.auth]
-env_vars = ["SOURCEGRAPH_ACCESS_TOKEN", "AMP_API_KEY"]
+env_vars = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "AMP_API_KEY"]
 setup_url = "https://ampcode.com/setup"
-browser_auth = false
-auth_instructions = "Set up your Sourcegraph access token and Amp API credentials"
+browser_auth = true
+auth_instructions = "Run 'amp login' or set an API key for your preferred provider"
+auth_mode = "any"
+cli_auth_command = "amp login"
+providers = [
+    {name = "Anthropic", env_var = "ANTHROPIC_API_KEY", key_hint = "sk-ant-*", setup_url = "https://console.anthropic.com/"},
+    {name = "OpenAI", env_var = "OPENAI_API_KEY", key_hint = "sk-*", setup_url = "https://platform.openai.com/api-keys"},
+    {name = "Amp", env_var = "AMP_API_KEY", setup_url = "https://ampcode.com/setup"},
+]
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/claude.toml
+++ b/npm/terminal-jarvis/config/tools/claude.toml
@@ -11,19 +11,20 @@ description = "Anthropic's Claude for code assistance"
 homepage = "https://claude.ai/"
 documentation = "https://docs.anthropic.com/claude/docs/claude-code"
 cli_command = "claude"
-requires_npm = true
+requires_npm = false
 requires_sudo = false
 status = "stable"
 
 [tool.install]
-command = "npm"
-args = ["install", "-g", "@anthropic-ai/claude-code"]
+command = "curl"
+args = ["-fsSL", "https://claude.ai/install.sh"]
+pipe_to = "bash"
 verify_command = "claude --version"
-post_install_message = "Claude installed successfully! Set ANTHROPIC_API_KEY to get started."
+post_install_message = "Claude Code installed successfully! Run 'claude' to log in and get started."
 
 [tool.update]
-command = "npm"
-args = ["update", "-g", "@anthropic-ai/claude-code"]
+command = "claude"
+args = ["update"]
 verify_command = "claude --version"
 
 [tool.auth]
@@ -31,6 +32,9 @@ env_vars = ["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"]
 setup_url = "https://console.anthropic.com/"
 browser_auth = true
 auth_instructions = "Visit console.anthropic.com to generate your API key"
+auth_mode = "any"
+default_env_var = "ANTHROPIC_API_KEY"
+key_format_hint = "sk-ant-*"
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/code.toml
+++ b/npm/terminal-jarvis/config/tools/code.toml
@@ -29,6 +29,9 @@ env_vars = ["OPENAI_API_KEY"]
 setup_url = ""
 browser_auth = false
 auth_instructions = "Set OPENAI_API_KEY."
+auth_mode = "any"
+default_env_var = "OPENAI_API_KEY"
+key_format_hint = "sk-*"
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/codex.toml
+++ b/npm/terminal-jarvis/config/tools/codex.toml
@@ -30,6 +30,10 @@ env_vars = ["OPENAI_API_KEY", "CODEX_API_KEY"]
 setup_url = "https://platform.openai.com/api-keys"
 browser_auth = false
 auth_instructions = "Visit OpenAI Platform to generate your API key"
+auth_mode = "any"
+default_env_var = "OPENAI_API_KEY"
+key_format_hint = "sk-*"
+cli_auth_command = "codex login"
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/copilot.toml
+++ b/npm/terminal-jarvis/config/tools/copilot.toml
@@ -31,6 +31,7 @@ env_vars = ["GITHUB_TOKEN", "GH_TOKEN"]
 setup_url = "https://github.com/settings/tokens"
 browser_auth = true
 auth_instructions = "Use '/login' command in Copilot CLI, or set GITHUB_TOKEN/GH_TOKEN, or authenticate via GitHub CLI (gh)"
+auth_mode = "any"
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/crush.toml
+++ b/npm/terminal-jarvis/config/tools/crush.toml
@@ -26,10 +26,17 @@ args = ["update", "-g", "@charmland/crush"]
 verify_command = "crush --version"
 
 [tool.auth]
-env_vars = ["CHARM_API_KEY"]
+env_vars = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "CHARM_API_KEY"]
 setup_url = "https://charm.sh/account"
 browser_auth = false
-auth_instructions = "Visit Charm account page to generate your API key"
+auth_instructions = "Set an API key for your preferred provider, or run 'crush login'"
+auth_mode = "any"
+cli_auth_command = "crush login"
+providers = [
+    {name = "Anthropic", env_var = "ANTHROPIC_API_KEY", key_hint = "sk-ant-*", setup_url = "https://console.anthropic.com/"},
+    {name = "OpenAI", env_var = "OPENAI_API_KEY", key_hint = "sk-*", setup_url = "https://platform.openai.com/api-keys"},
+    {name = "Charm", env_var = "CHARM_API_KEY", setup_url = "https://charm.sh/account"},
+]
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/cursor-agent.toml
+++ b/npm/terminal-jarvis/config/tools/cursor-agent.toml
@@ -29,6 +29,11 @@ env_vars = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
 setup_url = ""
 browser_auth = false
 auth_instructions = "Set OPENAI_API_KEY or ANTHROPIC_API_KEY environment variables."
+auth_mode = "any"
+providers = [
+    {name = "OpenAI", env_var = "OPENAI_API_KEY", key_hint = "sk-*", setup_url = "https://platform.openai.com/api-keys"},
+    {name = "Anthropic", env_var = "ANTHROPIC_API_KEY", key_hint = "sk-ant-*", setup_url = "https://console.anthropic.com/"},
+]
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/droid.toml
+++ b/npm/terminal-jarvis/config/tools/droid.toml
@@ -26,10 +26,18 @@ args = ["update"]
 verify_command = "droid --version"
 
 [tool.auth]
-env_vars = ["FACTORY_API_KEY"]
+env_vars = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "FACTORY_API_KEY"]
 setup_url = "https://app.factory.ai/"
 browser_auth = true
-auth_instructions = "Run 'droid login' to authenticate."
+auth_instructions = "Run 'droid login' or set an API key for your preferred provider"
+auth_mode = "any"
+default_env_var = "ANTHROPIC_API_KEY"
+cli_auth_command = "droid login"
+providers = [
+    {name = "Anthropic", env_var = "ANTHROPIC_API_KEY", key_hint = "sk-ant-*", setup_url = "https://console.anthropic.com/"},
+    {name = "OpenAI", env_var = "OPENAI_API_KEY", key_hint = "sk-*", setup_url = "https://platform.openai.com/api-keys"},
+    {name = "Factory", env_var = "FACTORY_API_KEY", setup_url = "https://app.factory.ai/"},
+]
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/eca.toml
+++ b/npm/terminal-jarvis/config/tools/eca.toml
@@ -26,10 +26,17 @@ args = ["upgrade"]
 verify_command = "eca --version"
 
 [tool.auth]
-env_vars = ["ECA_API_KEY"]
+env_vars = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "ECA_API_KEY"]
 setup_url = "https://eca.dev"
 browser_auth = true
-auth_instructions = "Run 'eca auth' to authenticate."
+auth_instructions = "Run 'eca auth' or set an API key for your preferred provider"
+auth_mode = "any"
+cli_auth_command = "eca auth"
+providers = [
+    {name = "Anthropic", env_var = "ANTHROPIC_API_KEY", key_hint = "sk-ant-*", setup_url = "https://console.anthropic.com/"},
+    {name = "OpenAI", env_var = "OPENAI_API_KEY", key_hint = "sk-*", setup_url = "https://platform.openai.com/api-keys"},
+    {name = "ECA", env_var = "ECA_API_KEY", setup_url = "https://eca.dev"},
+]
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/forge.toml
+++ b/npm/terminal-jarvis/config/tools/forge.toml
@@ -25,10 +25,17 @@ args = ["update", "-g", "forgecode"]
 verify_command = "forge --version"
 
 [tool.auth]
-env_vars = ["FORGE_API_KEY"]
+env_vars = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "FORGE_API_KEY"]
 setup_url = "https://forgecode.dev"
 browser_auth = true
-auth_instructions = "Run 'forge login' to authenticate."
+auth_instructions = "Run 'forge login' or set an API key for your preferred provider"
+auth_mode = "any"
+cli_auth_command = "forge login"
+providers = [
+    {name = "Anthropic", env_var = "ANTHROPIC_API_KEY", key_hint = "sk-ant-*", setup_url = "https://console.anthropic.com/"},
+    {name = "OpenAI", env_var = "OPENAI_API_KEY", key_hint = "sk-*", setup_url = "https://platform.openai.com/api-keys"},
+    {name = "Forge", env_var = "FORGE_API_KEY", setup_url = "https://forgecode.dev"},
+]
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/gemini.toml
+++ b/npm/terminal-jarvis/config/tools/gemini.toml
@@ -29,7 +29,11 @@ verify_command = "gemini --version"
 env_vars = ["GOOGLE_API_KEY", "GEMINI_API_KEY"]
 setup_url = "https://aistudio.google.com/app/apikey"
 browser_auth = true
-auth_instructions = "Visit Google AI Studio to generate your API key"
+auth_instructions = "Visit Google AI Studio to generate your API key, or run 'gemini auth'"
+auth_mode = "any"
+default_env_var = "GOOGLE_API_KEY"
+key_format_hint = "AIza*"
+cli_auth_command = "gemini auth"
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/goose.toml
+++ b/npm/terminal-jarvis/config/tools/goose.toml
@@ -40,6 +40,8 @@ env_vars = [
 setup_url = "https://block.github.io/goose/docs/getting-started/providers"
 browser_auth = true
 auth_instructions = "Run 'goose configure' to set up your preferred AI provider (Tetrate, OpenRouter, or manual API key configuration)"
+auth_mode = "any"
+cli_auth_command = "goose configure"
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/jules.toml
+++ b/npm/terminal-jarvis/config/tools/jules.toml
@@ -29,6 +29,7 @@ env_vars = []
 setup_url = "https://jules.google"
 browser_auth = true
 auth_instructions = "Run 'jules login' to authenticate with Google."
+auth_mode = "none"
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/kilocode.toml
+++ b/npm/terminal-jarvis/config/tools/kilocode.toml
@@ -25,10 +25,17 @@ args = ["update", "-g", "@kilocode/cli"]
 verify_command = "kilocode --version"
 
 [tool.auth]
-env_vars = ["KILO_API_KEY"]
+env_vars = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "KILO_API_KEY"]
 setup_url = "https://kilo.ai/settings"
 browser_auth = false
-auth_instructions = "Run 'kilocode auth' or set KILO_API_KEY."
+auth_instructions = "Run 'kilocode auth' or set an API key for your preferred provider"
+auth_mode = "any"
+cli_auth_command = "kilocode auth"
+providers = [
+    {name = "Anthropic", env_var = "ANTHROPIC_API_KEY", key_hint = "sk-ant-*", setup_url = "https://console.anthropic.com/"},
+    {name = "OpenAI", env_var = "OPENAI_API_KEY", key_hint = "sk-*", setup_url = "https://platform.openai.com/api-keys"},
+    {name = "Kilo", env_var = "KILO_API_KEY", setup_url = "https://kilo.ai/settings"},
+]
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/letta.toml
+++ b/npm/terminal-jarvis/config/tools/letta.toml
@@ -25,10 +25,17 @@ args = ["update", "-g", "@letta-ai/letta-code"]
 verify_command = "letta --version"
 
 [tool.auth]
-env_vars = ["LETTA_API_KEY"]
+env_vars = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "LETTA_API_KEY"]
 setup_url = "https://letta.com"
 browser_auth = true
-auth_instructions = "Run 'letta login' to authenticate."
+auth_instructions = "Run 'letta login' or set an API key for your preferred provider"
+auth_mode = "any"
+cli_auth_command = "letta login"
+providers = [
+    {name = "Anthropic", env_var = "ANTHROPIC_API_KEY", key_hint = "sk-ant-*", setup_url = "https://console.anthropic.com/"},
+    {name = "OpenAI", env_var = "OPENAI_API_KEY", key_hint = "sk-*", setup_url = "https://platform.openai.com/api-keys"},
+    {name = "Letta", env_var = "LETTA_API_KEY", setup_url = "https://letta.com"},
+]
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/llxprt.toml
+++ b/npm/terminal-jarvis/config/tools/llxprt.toml
@@ -30,6 +30,7 @@ env_vars = ["LLXPRT_API_KEY", "OPENAI_API_KEY"]
 setup_url = "https://platform.openai.com/api-keys"
 browser_auth = false
 auth_instructions = "Visit OpenAI Platform to generate your API key"
+auth_mode = "any"
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/nanocoder.toml
+++ b/npm/terminal-jarvis/config/tools/nanocoder.toml
@@ -29,6 +29,7 @@ env_vars = []
 setup_url = ""
 browser_auth = false
 auth_instructions = "Nanocoder runs locally."
+auth_mode = "none"
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/ollama.toml
+++ b/npm/terminal-jarvis/config/tools/ollama.toml
@@ -33,6 +33,7 @@ env_vars = []
 setup_url = ""
 browser_auth = false
 auth_instructions = "Ollama runs locally and does not typically require authentication."
+auth_mode = "none"
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/opencode.toml
+++ b/npm/terminal-jarvis/config/tools/opencode.toml
@@ -30,6 +30,8 @@ env_vars = ["OPENCODE_API_KEY", "OPENAI_API_KEY"]
 setup_url = "https://platform.openai.com/api-keys"
 browser_auth = false
 auth_instructions = "Visit OpenAI Platform to generate your API key"
+auth_mode = "any"
+cli_auth_command = "opencode auth"
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/pi.toml
+++ b/npm/terminal-jarvis/config/tools/pi.toml
@@ -29,6 +29,11 @@ env_vars = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
 setup_url = ""
 browser_auth = false
 auth_instructions = "Set OPENAI_API_KEY or ANTHROPIC_API_KEY."
+auth_mode = "any"
+providers = [
+    {name = "OpenAI", env_var = "OPENAI_API_KEY", key_hint = "sk-*", setup_url = "https://platform.openai.com/api-keys"},
+    {name = "Anthropic", env_var = "ANTHROPIC_API_KEY", key_hint = "sk-ant-*", setup_url = "https://console.anthropic.com/"},
+]
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/qwen.toml
+++ b/npm/terminal-jarvis/config/tools/qwen.toml
@@ -26,10 +26,17 @@ args = ["update", "-g", "@qwen-code/qwen-code"]
 verify_command = "qwen --version"
 
 [tool.auth]
-env_vars = ["QWEN_API_KEY"]
-setup_url = "https://dashscope.aliyun.com/"
+env_vars = ["DASHSCOPE_API_KEY", "QWEN_CODE_API_KEY", "OPENAI_API_KEY"]
+setup_url = "https://dashscope.console.aliyun.com/"
 browser_auth = false
-auth_instructions = "Visit DashScope to generate your API key"
+auth_instructions = "Visit DashScope to generate your API key, or use OpenAI-compatible mode"
+auth_mode = "any"
+default_env_var = "DASHSCOPE_API_KEY"
+providers = [
+    {name = "DashScope", env_var = "DASHSCOPE_API_KEY", setup_url = "https://dashscope.console.aliyun.com/"},
+    {name = "Qwen", env_var = "QWEN_CODE_API_KEY", setup_url = "https://dashscope.console.aliyun.com/"},
+    {name = "OpenAI", env_var = "OPENAI_API_KEY", key_hint = "sk-*", setup_url = "https://platform.openai.com/api-keys"},
+]
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/config/tools/vibe.toml
+++ b/npm/terminal-jarvis/config/tools/vibe.toml
@@ -27,10 +27,18 @@ args = ["update"]
 verify_command = "vibe --version"
 
 [tool.auth]
-env_vars = ["MISTRAL_API_KEY"]
+env_vars = ["MISTRAL_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"]
 setup_url = "https://console.mistral.ai/"
 browser_auth = false
-auth_instructions = "Run 'vibe auth' or set MISTRAL_API_KEY."
+auth_instructions = "Run 'vibe auth' or set an API key for your preferred provider"
+auth_mode = "any"
+default_env_var = "MISTRAL_API_KEY"
+cli_auth_command = "vibe auth"
+providers = [
+    {name = "Mistral", env_var = "MISTRAL_API_KEY", setup_url = "https://console.mistral.ai/"},
+    {name = "Anthropic", env_var = "ANTHROPIC_API_KEY", key_hint = "sk-ant-*", setup_url = "https://console.anthropic.com/"},
+    {name = "OpenAI", env_var = "OPENAI_API_KEY", key_hint = "sk-*", setup_url = "https://platform.openai.com/api-keys"},
+]
 
 [tool.features]
 supports_files = true

--- a/npm/terminal-jarvis/package-lock.json
+++ b/npm/terminal-jarvis/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terminal-jarvis",
-      "version": "0.0.76",
+      "version": "0.0.77",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/npm/terminal-jarvis/package.json
+++ b/npm/terminal-jarvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "description": "AI Coding Tools Wrapper - Unified interface for claude-code, gemini-cli, qwen-code, opencode, llxprt, codex, crush, goose, amp, and aider",
   "bin": {
     "terminal-jarvis": "bin/terminal-jarvis"

--- a/npm/terminal-jarvis/scripts/postinstall.js
+++ b/npm/terminal-jarvis/scripts/postinstall.js
@@ -8,7 +8,7 @@
  - Verify installation
 
  Version Hint (used by CI for consistency checks):
- Terminal Jarvis v0.0.75
+ Terminal Jarvis v0.0.77
 */
 
 const fs = require('fs');

--- a/npm/terminal-jarvis/src/index.ts
+++ b/npm/terminal-jarvis/src/index.ts
@@ -142,7 +142,7 @@ async function main() {
 }
 
 function showFallbackMessage() {
-  console.log("Terminal Jarvis v0.0.76");
+  console.log("Terminal Jarvis v0.0.77");
   console.log("");
   console.log("[ERROR] T.JARVIS SYSTEM: Could not locate or execute the core binary.");
   console.log("");


### PR DESCRIPTION
- Bump version to 0.0.77 across Cargo.toml, package.json, Formula, postinstall.js, and index.ts
- Update CHANGELOG.md with v0.0.77 entry (NPM workflow fix)
- Fix claude.toml install command: curl install.sh replaces deprecated npm global
- Sync tool configs regenerated by local-ci.sh

https://claude.ai/code/session_01HnU3W89EzU1eiLej28YE1t