### PR TITLE
chore(dependabot): reduce noise to 1 cargo PR max

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,32 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: "develop"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 1
-
+  # Core Rust dependencies — most critical, 1 PR max
   - package-ecosystem: "cargo"
     directory: "/"
     target-branch: "develop"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 1
+    groups:
+      rust-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
+  # GitHub Actions — security updates only (manual bumps for version updates)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+
+  # NPM — security updates only (manual bumps for version updates)
   - package-ecosystem: "npm"
     directory: "/npm/terminal-jarvis"
     target-branch: "develop"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 1
+      interval: "monthly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Reduces Dependabot PR noise by limiting to cargo-only version updates. Actions and NPM are set to security-only (limit: 0).