### PR TITLE
chore(dependabot): monthly schedule for all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,19 @@ updates:
     directory: "/"
     target-branch: "develop"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 1
 
   - package-ecosystem: "cargo"
     directory: "/"
     target-branch: "develop"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 1
 
   - package-ecosystem: "npm"
     directory: "/npm/terminal-jarvis"
     target-branch: "develop"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 1


### PR DESCRIPTION
Switches all ecosystems from weekly to monthly. Keeps 1 PR limit per ecosystem.