### PR TITLE
chore(release): integrate Options A-E and prepare 0.0.81

### DIFF
--- a/.github/workflows/cd-multiplatform.yml
+++ b/.github/workflows/cd-multiplatform.yml
@@ -68,13 +68,13 @@ jobs:
           targets: ${{ matrix.targets }}
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24.x'
           cache-dependency-path: adk/go.sum
 
       - name: Cache cargo registry (build)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -85,7 +85,7 @@ jobs:
       - name: Cache cross binary
         if: matrix.platform == 'linux'
         id: cache-cross
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/cross
           key: cross-${{ runner.os }}-v0.2
@@ -121,7 +121,7 @@ jobs:
         run: ./scripts/utils/generate-homebrew-release.sh --stage
 
       - name: Upload platform binaries
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: binaries-${{ matrix.platform }}
           path: |
@@ -142,7 +142,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry (publish)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -203,7 +203,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 
@@ -456,7 +456,7 @@ jobs:
       # Reuse the Linux binary built in build-multiplatform instead of
       # rebuilding from scratch. Saves the full Rust compilation time.
       - name: Download Linux binary artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: binaries-linux
           path: artifacts/binaries-linux
@@ -475,7 +475,7 @@ jobs:
           echo "Staged binary: $BINARY -> target/release/terminal-jarvis"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/cd-npm-beta-release.yml
+++ b/.github/workflows/cd-npm-beta-release.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: '18'
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/cd-npm-stable-release.yml
+++ b/.github/workflows/cd-npm-stable-release.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: '18'
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 # Minimal permissions by default; specific jobs can elevate
 permissions:
@@ -66,7 +67,7 @@ jobs:
 
     - name: Cache cargo dependencies
       if: ${{ matrix.suite == 'rust' }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/registry
@@ -105,7 +106,7 @@ jobs:
     # Go code quality + tests
     - name: Setup Go
       if: ${{ matrix.suite == 'go' }}
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: '1.24.x'
         cache-dependency-path: adk/go.sum
@@ -139,7 +140,7 @@ jobs:
 
     - name: Cache cargo dependencies
       if: ${{ matrix.suite == 'npm' }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/registry
@@ -154,7 +155,7 @@ jobs:
 
     - name: Setup Node.js
       if: ${{ matrix.suite == 'npm' }}
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node }}
 
@@ -217,7 +218,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
 
     - name: Cache cargo dependencies and tools
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/registry
@@ -286,12 +287,13 @@ jobs:
     # SBOM and vulnerability scan (Anchore)
     - name: Scan workspace with Anchore
       id: anchore
-      uses: anchore/scan-action@v4
+      uses: anchore/scan-action@v7
       with:
         path: .
         fail-build: false
         severity-cutoff: critical
         output-format: sarif
+        cache-db: true
 
     - name: Check scan results
       run: |

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -31,7 +31,7 @@ jobs:
           repository-name: ${{ github.repository }}
 
       - name: Upload weekly issue report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: weekly-issue-report
           path: ${{ steps.health_check.outputs.issue-summary }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload README diff artifact
         if: steps.sync_check.outputs.changed == 'true'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: readme-diff
           path: ${{ steps.sync_check.outputs.diff-path }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.81] - 2026-05-08
+
+### Added
+- **Hermes Agent**: Added catalog entry with canonical NousResearch installer, CLI `hermes`, and update command `hermes update`
+- **OpenClaw**: Added catalog entry as npm package `openclaw` with CLI `openclaw`, update command `openclaw update --yes --no-restart`, and OpenRouter onboarding support
+- **Tool Catalog Validation**: Added offline validation tests and fixtures to catch catalog drift before release
+
+### Fixed
+- **Headless Update-All**: `update all` now only attempts to update installed tools, preventing errors in headless/CI environments
+- **Tool Catalog Drift**: Corrected package metadata for `@just-every/code` (bin `coder`), `@nanocollective/nanocoder`, and `@earendil-works/pi-coding-agent` in root and npm-copied configs
+- **Documentation Counts**: Fixed README tool counts (22 -> 23), cli_logic module count (22 -> 19), and docs link tool count (11 -> 23)
+
+### Security
+- **SECURITY.md Restored**: Comprehensive security documentation covering supply chain practices, credential storage, and reporting procedures
+
 ## [0.0.80] - 2026-03-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "libsql"
-version = "0.9.29"
+version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2329faffc510cc3c6b4f00169a39177cc7099d3ed7647fc92f7cf26e53a8d976"
+checksum = "30fe980ac5693ed1f3db490559fb578885e913a018df64af8a1a46e1959a78df"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1479,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "libsql-ffi"
-version = "0.9.29"
+version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd1c1662822495393327856774f6803be25d85bfdcd5b9d4af35458f5daaf75"
+checksum = "0be1da6f123ceb2cd23f469883415cab9ee963286a85d61e22afb8b12e15e681"
 dependencies = [
  "bindgen",
  "cc",
@@ -1491,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "libsql-hrana"
-version = "0.9.29"
+version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646d0aa75e412769018422f0da798f72e93bd51964f0b2ddad4317aa779ae444"
+checksum = "d3358538b52cfcf9af4fe7aeb57d6843aafed2e8af80807bd636fd1448e94ea7"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "libsql-rusqlite"
-version = "0.9.29"
+version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4ce3a78c6e3c2b23b02ab6272df8340e1c53380497979d456882254f348d5f"
+checksum = "b646f94fc1d266e481c38a2d44d6d9d1be3ad04b56b90457acfb310dc450030e"
 dependencies = [
  "bitflags 2.10.0",
  "fallible-iterator 0.2.0",
@@ -1535,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "libsql-sys"
-version = "0.9.29"
+version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3c326fcfc36fe7578238d5ee6b58c529f8c76372acd61ec50267529cdaff95"
+checksum = "90725458cc4461bc82f8f7983e80b002ea4f64b5184e1462f252d0dd74b122f5"
 dependencies = [
  "bytes",
  "libsql-ffi",
@@ -1549,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "libsql_replication"
-version = "0.9.29"
+version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9a2e469ac8400659bd31f81a745908bcc5cb6b40be2f2ff8de90b15bec5501"
+checksum = "3bba5c9b3a26aca06d70f6a3646ba341cf574a548355353fe135af524b1b77cc"
 dependencies = [
  "aes",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-jarvis"
-version = "0.0.80"
+version = "0.0.81"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-jarvis"
-version = "0.0.80"
+version = "0.0.81"
 edition = "2021"
 description = "A thin Rust wrapper that provides a unified interface for managing and running AI coding tools"
 authors = ["BA-CalderonMorales"]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ brew tap ba-calderonmorales/terminal-jarvis && brew install terminal-jarvis  # H
 | Feature | Description |
 |:--------|:------------|
 | **Interactive Interface** | Beautiful terminal UI with ASCII art, themed menus, and keyboard navigation for a polished command-line experience. |
-| **23 AI Tools Supported** | Claude, Gemini, Qwen, OpenCode, Codex, Aider, Goose, Amp, Crush, LLXPRT, and many more - all manageable from a single interface. |
+| **25 AI Tools Supported** | Claude, Gemini, Qwen, OpenCode, Codex, Aider, Goose, Amp, Crush, LLXPRT, and many more - all manageable from a single interface. |
 | **Integrated Installation** | Install, update, or uninstall any supported AI tool directly from the menu without leaving the terminal. |
 | **Session Continuity** | Preserves your terminal session state during browser-based authentication flows. Currently in development with expanding coverage. |
 
@@ -69,7 +69,7 @@ Full guides at **[Terminal Jarvis Docs](https://ba-calderonmorales.github.io/my-
 | Guide | Description |
 |:------|:------------|
 | [Installation](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/quick_start/installation/) | Step-by-step platform setup for NPM, Cargo, and Homebrew with troubleshooting tips for common issues. |
-| [AI Tools](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/quick_start/ai-tools/) | Detailed overview of all 23 supported AI coding assistants including authentication requirements and capabilities. |
+| [AI Tools](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/quick_start/ai-tools/) | Detailed overview of all 25 supported AI coding assistants including authentication requirements and capabilities. |
 | [Configuration](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/quick_start/configuration/) | Customize themes, keybindings, default tools, and environment variables to match your workflow. |
 | [Architecture](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/details/architecture/) | Technical deep-dive into the Rust codebase, module organization, and design decisions. |
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Unified command center for AI coding tools**
 
-Manage Claude, Gemini, Qwen, and 19 more AI assistants from one terminal interface.
+Manage Claude, Gemini, Qwen, and 20 more AI assistants from one terminal interface.
 
 [![NPM Version](https://img.shields.io/npm/v/terminal-jarvis.svg?logo=npm&style=flat-square)](https://www.npmjs.com/package/terminal-jarvis)
 [![Crates.io](https://img.shields.io/crates/v/terminal-jarvis.svg?logo=rust&style=flat-square)](https://crates.io/crates/terminal-jarvis)
@@ -54,7 +54,7 @@ brew tap ba-calderonmorales/terminal-jarvis && brew install terminal-jarvis  # H
 | Feature | Description |
 |:--------|:------------|
 | **Interactive Interface** | Beautiful terminal UI with ASCII art, themed menus, and keyboard navigation for a polished command-line experience. |
-| **22 AI Tools Supported** | Claude, Gemini, Qwen, OpenCode, Codex, Aider, Goose, Amp, Crush, LLXPRT, and many more - all manageable from a single interface. |
+| **23 AI Tools Supported** | Claude, Gemini, Qwen, OpenCode, Codex, Aider, Goose, Amp, Crush, LLXPRT, and many more - all manageable from a single interface. |
 | **Integrated Installation** | Install, update, or uninstall any supported AI tool directly from the menu without leaving the terminal. |
 | **Session Continuity** | Preserves your terminal session state during browser-based authentication flows. Currently in development with expanding coverage. |
 
@@ -69,7 +69,7 @@ Full guides at **[Terminal Jarvis Docs](https://ba-calderonmorales.github.io/my-
 | Guide | Description |
 |:------|:------------|
 | [Installation](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/quick_start/installation/) | Step-by-step platform setup for NPM, Cargo, and Homebrew with troubleshooting tips for common issues. |
-| [AI Tools](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/quick_start/ai-tools/) | Detailed overview of all 11 supported AI coding assistants including authentication requirements and capabilities. |
+| [AI Tools](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/quick_start/ai-tools/) | Detailed overview of all 23 supported AI coding assistants including authentication requirements and capabilities. |
 | [Configuration](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/quick_start/configuration/) | Customize themes, keybindings, default tools, and environment variables to match your workflow. |
 | [Architecture](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/details/architecture/) | Technical deep-dive into the Rust codebase, module organization, and design decisions. |
 
@@ -83,7 +83,7 @@ terminal-jarvis/
 ├── src/                           # Rust application
 │   ├── main.rs                    # Entry point
 │   ├── cli.rs                     # CLI definitions
-│   ├── cli_logic/                 # Business logic (22 modules)
+│   ├── cli_logic/                 # Business logic (19 modules)
 │   ├── auth_manager/              # Authentication (8 modules)
 │   ├── config/                    # Configuration (6 modules)
 │   ├── services/                  # External integrations (6 modules)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,183 @@
+# Security Policy
+
+> **Status:** Active monitoring with automated vulnerability scanning
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.0.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+1. **Do not open a public issue**
+2. Email: [security@ba-calderonmorales.dev](mailto:security@ba-calderonmorales.dev)
+3. Include:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if any)
+
+We aim to respond within 48 hours and will keep you updated on the remediation progress.
+
+---
+
+## Supply Chain Security
+
+This project implements defense-in-depth measures to protect against supply chain attacks.
+
+### Dependency Management
+
+#### NPM (JavaScript/TypeScript)
+
+- **Pinned Versions:** All dependencies use exact versions (no `^` or `~`)
+- **Lockfile Verification:** CI verifies `package-lock.json` is in sync with `package.json`
+- **Clean Install:** CI uses `npm ci` instead of `npm install` for reproducible builds
+- **Audit Level:** CI fails on moderate or higher severity vulnerabilities
+
+```bash
+# Verify lockfile sync locally
+cd npm/terminal-jarvis
+npm install --package-lock-only
+git diff package-lock.json
+
+# Run security audit
+npm audit --audit-level=moderate
+```
+
+#### Cargo (Rust)
+
+- **Locked Builds:** CI uses `cargo build --locked` to ensure `Cargo.lock` is current
+- **Cargo.lock Committed:** Lockfile is tracked in version control
+- **cargo-audit:** Automated security scanning for Rust dependencies
+- **cargo-deny:** License and advisory checking
+
+```bash
+# Verify locked build
+cargo build --locked
+
+# Run security audit
+cargo audit
+
+# Run cargo-deny checks
+cargo deny check advisories bans sources
+```
+
+### CI Security Checks
+
+Our continuous integration pipeline includes:
+
+| Check              | Tool          | Severity Threshold |
+|--------------------|---------------|--------------------|
+| NPM Audit          | npm audit     | Moderate+          |
+| Rust Audit         | cargo-audit   | Warnings+          |
+| License Check      | cargo-deny    | Banned licenses    |
+| Secret Scanning    | Gitleaks      | All secrets        |
+| Shell Script Check | ShellCheck    | Style issues       |
+| SBOM Scan          | Anchore       | Critical           |
+
+### Install Scripts
+
+The NPM package includes a `postinstall` script that downloads platform-specific binaries:
+
+**File:** `npm/terminal-jarvis/scripts/postinstall.js`
+
+- Downloads from GitHub releases (HTTPS only)
+- No automatic execution of downloaded binaries
+- Graceful fallback if download fails
+- Checksums not yet implemented (planned for v0.1.0)
+
+### Binary Verification
+
+Pre-built binaries are available for:
+- macOS (x64, arm64)
+- Linux (x64, arm64)
+- Windows (x64, arm64)
+
+Download from: [GitHub Releases](https://github.com/BA-CalderonMorales/terminal-jarvis/releases)
+
+**Verification (manual):**
+```bash
+# TODO: Add checksum verification in v0.1.0
+# sha256sum -c terminal-jarvis-linux.tar.gz.sha256
+```
+
+---
+
+## Credential Security
+
+### Storage
+
+API keys and credentials are stored with encryption:
+
+| Feature                  | Status       | Version |
+|--------------------------|--------------|---------|
+| Platform Keychain        | Implemented  | 0.0.80+ |
+| AES-256-GCM Fallback     | Implemented  | 0.0.80+ |
+| Argon2 Key Derivation    | Implemented  | 0.0.80+ |
+| Plaintext Migration      | Supported    | Current |
+
+### Current Behavior
+
+- Credentials stored at: `~/.config/terminal-jarvis/credentials.toml`
+- Default: **Plaintext** on first use (backward compatible)
+- Encryption: Run `jarvis security encrypt` to migrate to encrypted storage
+- Migration: Automatic encryption on first write after upgrade if configured
+
+### Encryption Usage
+
+```bash
+# Check security status
+jarvis security status
+
+# Encrypt existing credentials
+jarvis security encrypt
+```
+
+---
+
+## Security Features
+
+### Zero-Trust Model Loading
+
+The `SecureModelLoader` implements:
+- Allowlist-only model loading
+- SHA-256 hash verification
+- Auto-download disabled
+- Cache verification on each access
+
+### Input Validation
+
+All external input passes through `SecurityValidator`:
+- Path traversal detection
+- Command injection prevention
+- Shell escape detection
+
+### Browser Security
+
+See `src/security/browser_attack_tests.rs` for:
+- Localhost attack prevention
+- Browser cache poisoning tests
+- CORS misconfiguration detection
+
+---
+
+## Security Score Targets
+
+| Metric                  | Tool       | Target | Current |
+|-------------------------|------------|--------|---------|
+| Supply Chain Security   | Socket.dev | 100/100| In Progress |
+| Vulnerability Alerts    | GitHub     | 0      | 0       |
+| Dependency Age          | Dependabot | Current| Weekly  |
+| Secrets in Code         | Gitleaks   | 0      | 0       |
+
+---
+
+## Related Documentation
+
+- [AGENTS.md](./AGENTS.md) - Development practices for AI-assisted contributions
+- [README.md](./README.md) - General project information
+- Issue #62 - Supply chain hardening
+- Issue #59 - Credential encryption

--- a/config/tools/code.toml
+++ b/config/tools/code.toml
@@ -8,7 +8,7 @@ config_key = "code"
 description = "Fork of Codex AI - multi-provider coding agent"
 homepage = "https://github.com/just-every/code"
 documentation = "https://github.com/just-every/code"
-cli_command = "code"
+cli_command = "coder"
 requires_npm = true
 requires_sudo = false
 status = "experimental"
@@ -16,13 +16,13 @@ status = "experimental"
 [tool.install]
 command = "npm"
 args = ["install", "-g", "@just-every/code"]
-verify_command = "code --version"
-post_install_message = "Code installed! If 'code' conflicts with VS Code, check alias."
+verify_command = "coder --version"
+post_install_message = "Code installed! Run it with 'coder'."
 
 [tool.update]
 command = "npm"
 args = ["update", "-g", "@just-every/code"]
-verify_command = "code --version"
+verify_command = "coder --version"
 
 [tool.auth]
 env_vars = ["OPENAI_API_KEY"]

--- a/config/tools/hermes.toml
+++ b/config/tools/hermes.toml
@@ -1,0 +1,60 @@
+# =============================================================================
+# HERMES AGENT - Nous Research terminal agent
+# =============================================================================
+
+[tool]
+display_name = "Hermes Agent"
+config_key = "hermes"
+description = "Nous Research's terminal AI agent with CLI, TUI, tools, skills, and messaging gateway support"
+homepage = "https://hermes-agent.nousresearch.com/"
+documentation = "https://hermes-agent.nousresearch.com/docs/"
+cli_command = "hermes"
+requires_npm = false
+requires_sudo = false
+status = "experimental"
+
+[tool.install]
+command = "bash"
+args = [
+    "-lc",
+    "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup",
+]
+verify_command = "hermes --version"
+post_install_message = "Hermes Agent installed successfully! Run 'hermes setup' or 'hermes model' to configure a provider."
+
+[tool.update]
+command = "hermes"
+args = ["update"]
+verify_command = "hermes --version"
+
+[tool.auth]
+env_vars = [
+    "OPENROUTER_API_KEY",
+    "AI_GATEWAY_API_KEY",
+    "HF_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+]
+setup_url = "https://hermes-agent.nousresearch.com/docs/integrations/providers/"
+browser_auth = true
+auth_instructions = "Run 'hermes setup', 'hermes model', or set a supported provider key in ~/.hermes/.env. Hermes supports browser/OAuth providers and API-key providers such as OpenRouter, AI Gateway, Hugging Face, Anthropic, OpenAI-compatible endpoints, and Gemini."
+auth_mode = "any"
+default_env_var = "OPENROUTER_API_KEY"
+cli_auth_command = "hermes setup"
+providers = [
+    {name = "OpenRouter", env_var = "OPENROUTER_API_KEY", key_hint = "sk-or-*", setup_url = "https://openrouter.ai/keys"},
+    {name = "AI Gateway", env_var = "AI_GATEWAY_API_KEY", setup_url = "https://ai-gateway.vercel.sh/"},
+    {name = "Hugging Face", env_var = "HF_TOKEN", key_hint = "hf_*", setup_url = "https://huggingface.co/settings/tokens"},
+    {name = "Anthropic", env_var = "ANTHROPIC_API_KEY", key_hint = "sk-ant-*", setup_url = "https://console.anthropic.com/"},
+    {name = "OpenAI-compatible", env_var = "OPENAI_API_KEY", key_hint = "sk-*", setup_url = "https://platform.openai.com/api-keys"},
+    {name = "Google Gemini", env_var = "GOOGLE_API_KEY", key_hint = "AIza*", setup_url = "https://aistudio.google.com/app/apikey"},
+]
+
+[tool.features]
+supports_files = true
+supports_streaming = true
+supports_conversation = true
+max_context_tokens = 200000
+supported_languages = ["all"]

--- a/config/tools/nanocoder.toml
+++ b/config/tools/nanocoder.toml
@@ -6,8 +6,8 @@
 display_name = "Nanocoder"
 config_key = "nanocoder"
 description = "Local-first coding agent"
-homepage = "https://github.com/motesoftware/nanocoder"
-documentation = "https://github.com/motesoftware/nanocoder"
+homepage = "https://github.com/Nano-Collective/nanocoder"
+documentation = "https://github.com/Nano-Collective/nanocoder"
 cli_command = "nanocoder"
 requires_npm = true
 requires_sudo = false
@@ -15,13 +15,13 @@ status = "experimental"
 
 [tool.install]
 command = "npm"
-args = ["install", "-g", "@motesoftware/nanocoder"]
+args = ["install", "-g", "@nanocollective/nanocoder"]
 verify_command = "nanocoder --version"
 post_install_message = "Nanocoder installed!"
 
 [tool.update]
 command = "npm"
-args = ["update", "-g", "@motesoftware/nanocoder"]
+args = ["update", "-g", "@nanocollective/nanocoder"]
 verify_command = "nanocoder --version"
 
 [tool.auth]

--- a/config/tools/openclaw.toml
+++ b/config/tools/openclaw.toml
@@ -1,0 +1,44 @@
+# =============================================================================
+# OPENCLAW - AI gateway and coding agent
+# =============================================================================
+
+[tool]
+display_name = "OpenClaw"
+config_key = "openclaw"
+description = "Open-source AI coding assistant and multi-channel local gateway"
+homepage = "https://openclaw.ai/"
+documentation = "https://docs.openclaw.ai/"
+cli_command = "openclaw"
+requires_npm = true
+requires_sudo = false
+status = "experimental"
+
+[tool.install]
+command = "npm"
+args = ["install", "-g", "openclaw"]
+verify_command = "openclaw --version"
+post_install_message = "OpenClaw installed successfully! Run 'openclaw onboard' or 'openclaw setup' to configure providers and gateway settings."
+
+[tool.update]
+command = "openclaw"
+args = ["update", "--yes", "--no-restart"]
+verify_command = "openclaw --version"
+
+[tool.auth]
+env_vars = ["OPENROUTER_API_KEY"]
+setup_url = "https://docs.openclaw.ai/"
+browser_auth = true
+auth_instructions = "Run 'openclaw onboard' to configure providers. For headless OpenRouter setup, use 'openclaw onboard --auth-choice openrouter-api-key'. OpenClaw can manage local gateway services, ports, webhooks, and token storage, so review gateway and provider settings before enabling persistent services."
+auth_mode = "any"
+default_env_var = "OPENROUTER_API_KEY"
+cli_auth_command = "openclaw onboard"
+providers = [
+    {name = "OpenRouter", env_var = "OPENROUTER_API_KEY", key_hint = "sk-or-*", setup_url = "https://openrouter.ai/keys"},
+]
+
+[tool.features]
+supports_files = true
+supports_streaming = true
+supports_conversation = true
+max_context_tokens = 200000
+supported_languages = ["all"]

--- a/config/tools/pi.toml
+++ b/config/tools/pi.toml
@@ -6,8 +6,8 @@
 display_name = "Pi"
 config_key = "pi"
 description = "Terminal-based coding agent"
-homepage = "https://github.com/mariozechner/pi-coding-agent"
-documentation = "https://github.com/mariozechner/pi-coding-agent"
+homepage = "https://github.com/earendil-works/pi-mono"
+documentation = "https://github.com/earendil-works/pi-mono"
 cli_command = "pi"
 requires_npm = true
 requires_sudo = false
@@ -15,13 +15,13 @@ status = "experimental"
 
 [tool.install]
 command = "npm"
-args = ["install", "-g", "@mariozechner/pi-coding-agent"]
+args = ["install", "-g", "@earendil-works/pi-coding-agent"]
 verify_command = "pi --version"
 post_install_message = "Pi installed!"
 
 [tool.update]
 command = "npm"
-args = ["update", "-g", "@mariozechner/pi-coding-agent"]
+args = ["update", "-g", "@earendil-works/pi-coding-agent"]
 verify_command = "pi --version"
 
 [tool.auth]

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -573,9 +573,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
-            "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+            "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
             "cpu": [
                 "arm"
             ],
@@ -587,9 +587,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
-            "integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+            "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
             "cpu": [
                 "arm64"
             ],
@@ -601,9 +601,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
-            "integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+            "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
             "cpu": [
                 "arm64"
             ],
@@ -615,9 +615,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
-            "integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+            "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
             "cpu": [
                 "x64"
             ],
@@ -629,9 +629,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
-            "integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+            "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
             "cpu": [
                 "arm64"
             ],
@@ -643,9 +643,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
-            "integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+            "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
             "cpu": [
                 "x64"
             ],
@@ -657,9 +657,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
-            "integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+            "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
             "cpu": [
                 "arm"
             ],
@@ -671,9 +671,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
-            "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+            "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
             "cpu": [
                 "arm"
             ],
@@ -685,9 +685,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
-            "integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+            "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
             "cpu": [
                 "arm64"
             ],
@@ -699,9 +699,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
-            "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+            "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
             "cpu": [
                 "arm64"
             ],
@@ -713,9 +713,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
-            "integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+            "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
             "cpu": [
                 "loong64"
             ],
@@ -727,9 +727,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
-            "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+            "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
             "cpu": [
                 "loong64"
             ],
@@ -741,9 +741,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
-            "integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+            "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -755,9 +755,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
-            "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+            "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
             "cpu": [
                 "ppc64"
             ],
@@ -769,9 +769,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
-            "integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+            "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
             "cpu": [
                 "riscv64"
             ],
@@ -783,9 +783,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
-            "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+            "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -797,9 +797,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
-            "integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+            "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
             "cpu": [
                 "s390x"
             ],
@@ -811,9 +811,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
-            "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+            "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
             "cpu": [
                 "x64"
             ],
@@ -825,9 +825,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
-            "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+            "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
             "cpu": [
                 "x64"
             ],
@@ -839,9 +839,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
-            "integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+            "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
             "cpu": [
                 "x64"
             ],
@@ -853,9 +853,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
-            "integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+            "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
             "cpu": [
                 "arm64"
             ],
@@ -867,9 +867,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
-            "integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+            "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
             "cpu": [
                 "arm64"
             ],
@@ -881,9 +881,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
-            "integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+            "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
             "cpu": [
                 "ia32"
             ],
@@ -895,9 +895,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
-            "integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+            "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
             "cpu": [
                 "x64"
             ],
@@ -909,9 +909,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
-            "integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+            "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
             "cpu": [
                 "x64"
             ],
@@ -1603,9 +1603,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1616,9 +1616,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
             "dev": true,
             "funding": [
                 {
@@ -1694,9 +1694,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.55.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
-            "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+            "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1710,31 +1710,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.55.1",
-                "@rollup/rollup-android-arm64": "4.55.1",
-                "@rollup/rollup-darwin-arm64": "4.55.1",
-                "@rollup/rollup-darwin-x64": "4.55.1",
-                "@rollup/rollup-freebsd-arm64": "4.55.1",
-                "@rollup/rollup-freebsd-x64": "4.55.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
-                "@rollup/rollup-linux-arm-musleabihf": "4.55.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.55.1",
-                "@rollup/rollup-linux-arm64-musl": "4.55.1",
-                "@rollup/rollup-linux-loong64-gnu": "4.55.1",
-                "@rollup/rollup-linux-loong64-musl": "4.55.1",
-                "@rollup/rollup-linux-ppc64-gnu": "4.55.1",
-                "@rollup/rollup-linux-ppc64-musl": "4.55.1",
-                "@rollup/rollup-linux-riscv64-gnu": "4.55.1",
-                "@rollup/rollup-linux-riscv64-musl": "4.55.1",
-                "@rollup/rollup-linux-s390x-gnu": "4.55.1",
-                "@rollup/rollup-linux-x64-gnu": "4.55.1",
-                "@rollup/rollup-linux-x64-musl": "4.55.1",
-                "@rollup/rollup-openbsd-x64": "4.55.1",
-                "@rollup/rollup-openharmony-arm64": "4.55.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.55.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.55.1",
-                "@rollup/rollup-win32-x64-gnu": "4.55.1",
-                "@rollup/rollup-win32-x64-msvc": "4.55.1",
+                "@rollup/rollup-android-arm-eabi": "4.60.3",
+                "@rollup/rollup-android-arm64": "4.60.3",
+                "@rollup/rollup-darwin-arm64": "4.60.3",
+                "@rollup/rollup-darwin-x64": "4.60.3",
+                "@rollup/rollup-freebsd-arm64": "4.60.3",
+                "@rollup/rollup-freebsd-x64": "4.60.3",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+                "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+                "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+                "@rollup/rollup-linux-arm64-musl": "4.60.3",
+                "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+                "@rollup/rollup-linux-loong64-musl": "4.60.3",
+                "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+                "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+                "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+                "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+                "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+                "@rollup/rollup-linux-x64-gnu": "4.60.3",
+                "@rollup/rollup-linux-x64-musl": "4.60.3",
+                "@rollup/rollup-openbsd-x64": "4.60.3",
+                "@rollup/rollup-openharmony-arm64": "4.60.3",
+                "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+                "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+                "@rollup/rollup-win32-x64-gnu": "4.60.3",
+                "@rollup/rollup-win32-x64-msvc": "4.60.3",
                 "fsevents": "~2.3.2"
             }
         },
@@ -1952,9 +1952,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "version": "7.3.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+            "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/homebrew/Formula/terminal-jarvis.rb
+++ b/homebrew/Formula/terminal-jarvis.rb
@@ -1,26 +1,26 @@
 class TerminalJarvis < Formula
   desc "A unified command center for AI coding tools"
   homepage "https://github.com/BA-CalderonMorales/terminal-jarvis"
-  version "0.0.80"
+  version "0.0.81"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.79/terminal-jarvis-mac.tar.gz"
+      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.81/terminal-jarvis-mac.tar.gz"
       sha256 "SKIP_CHECK"
     elsif Hardware::CPU.arm?
-      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.79/terminal-jarvis-mac.tar.gz"
+      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.81/terminal-jarvis-mac.tar.gz"
       sha256 "SKIP_CHECK"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.79/terminal-jarvis-linux.tar.gz"
+      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.81/terminal-jarvis-linux.tar.gz"
       sha256 "SKIP_CHECK"
     else
       # Fallback for other Linux architectures
-      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.79/terminal-jarvis-linux.tar.gz"
+      url "https://github.com/BA-CalderonMorales/terminal-jarvis/releases/download/v0.0.81/terminal-jarvis-linux.tar.gz"
       sha256 "SKIP_CHECK"
     end
   end

--- a/npm/terminal-jarvis/config/tools/code.toml
+++ b/npm/terminal-jarvis/config/tools/code.toml
@@ -8,7 +8,7 @@ config_key = "code"
 description = "Fork of Codex AI - multi-provider coding agent"
 homepage = "https://github.com/just-every/code"
 documentation = "https://github.com/just-every/code"
-cli_command = "code"
+cli_command = "coder"
 requires_npm = true
 requires_sudo = false
 status = "experimental"
@@ -16,13 +16,13 @@ status = "experimental"
 [tool.install]
 command = "npm"
 args = ["install", "-g", "@just-every/code"]
-verify_command = "code --version"
-post_install_message = "Code installed! If 'code' conflicts with VS Code, check alias."
+verify_command = "coder --version"
+post_install_message = "Code installed! Run it with 'coder'."
 
 [tool.update]
 command = "npm"
 args = ["update", "-g", "@just-every/code"]
-verify_command = "code --version"
+verify_command = "coder --version"
 
 [tool.auth]
 env_vars = ["OPENAI_API_KEY"]

--- a/npm/terminal-jarvis/config/tools/hermes.toml
+++ b/npm/terminal-jarvis/config/tools/hermes.toml
@@ -1,0 +1,60 @@
+# =============================================================================
+# HERMES AGENT - Nous Research terminal agent
+# =============================================================================
+
+[tool]
+display_name = "Hermes Agent"
+config_key = "hermes"
+description = "Nous Research's terminal AI agent with CLI, TUI, tools, skills, and messaging gateway support"
+homepage = "https://hermes-agent.nousresearch.com/"
+documentation = "https://hermes-agent.nousresearch.com/docs/"
+cli_command = "hermes"
+requires_npm = false
+requires_sudo = false
+status = "experimental"
+
+[tool.install]
+command = "bash"
+args = [
+    "-lc",
+    "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup",
+]
+verify_command = "hermes --version"
+post_install_message = "Hermes Agent installed successfully! Run 'hermes setup' or 'hermes model' to configure a provider."
+
+[tool.update]
+command = "hermes"
+args = ["update"]
+verify_command = "hermes --version"
+
+[tool.auth]
+env_vars = [
+    "OPENROUTER_API_KEY",
+    "AI_GATEWAY_API_KEY",
+    "HF_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+]
+setup_url = "https://hermes-agent.nousresearch.com/docs/integrations/providers/"
+browser_auth = true
+auth_instructions = "Run 'hermes setup', 'hermes model', or set a supported provider key in ~/.hermes/.env. Hermes supports browser/OAuth providers and API-key providers such as OpenRouter, AI Gateway, Hugging Face, Anthropic, OpenAI-compatible endpoints, and Gemini."
+auth_mode = "any"
+default_env_var = "OPENROUTER_API_KEY"
+cli_auth_command = "hermes setup"
+providers = [
+    {name = "OpenRouter", env_var = "OPENROUTER_API_KEY", key_hint = "sk-or-*", setup_url = "https://openrouter.ai/keys"},
+    {name = "AI Gateway", env_var = "AI_GATEWAY_API_KEY", setup_url = "https://ai-gateway.vercel.sh/"},
+    {name = "Hugging Face", env_var = "HF_TOKEN", key_hint = "hf_*", setup_url = "https://huggingface.co/settings/tokens"},
+    {name = "Anthropic", env_var = "ANTHROPIC_API_KEY", key_hint = "sk-ant-*", setup_url = "https://console.anthropic.com/"},
+    {name = "OpenAI-compatible", env_var = "OPENAI_API_KEY", key_hint = "sk-*", setup_url = "https://platform.openai.com/api-keys"},
+    {name = "Google Gemini", env_var = "GOOGLE_API_KEY", key_hint = "AIza*", setup_url = "https://aistudio.google.com/app/apikey"},
+]
+
+[tool.features]
+supports_files = true
+supports_streaming = true
+supports_conversation = true
+max_context_tokens = 200000
+supported_languages = ["all"]

--- a/npm/terminal-jarvis/config/tools/nanocoder.toml
+++ b/npm/terminal-jarvis/config/tools/nanocoder.toml
@@ -6,8 +6,8 @@
 display_name = "Nanocoder"
 config_key = "nanocoder"
 description = "Local-first coding agent"
-homepage = "https://github.com/motesoftware/nanocoder"
-documentation = "https://github.com/motesoftware/nanocoder"
+homepage = "https://github.com/Nano-Collective/nanocoder"
+documentation = "https://github.com/Nano-Collective/nanocoder"
 cli_command = "nanocoder"
 requires_npm = true
 requires_sudo = false
@@ -15,13 +15,13 @@ status = "experimental"
 
 [tool.install]
 command = "npm"
-args = ["install", "-g", "@motesoftware/nanocoder"]
+args = ["install", "-g", "@nanocollective/nanocoder"]
 verify_command = "nanocoder --version"
 post_install_message = "Nanocoder installed!"
 
 [tool.update]
 command = "npm"
-args = ["update", "-g", "@motesoftware/nanocoder"]
+args = ["update", "-g", "@nanocollective/nanocoder"]
 verify_command = "nanocoder --version"
 
 [tool.auth]

--- a/npm/terminal-jarvis/config/tools/openclaw.toml
+++ b/npm/terminal-jarvis/config/tools/openclaw.toml
@@ -1,0 +1,44 @@
+# =============================================================================
+# OPENCLAW - AI gateway and coding agent
+# =============================================================================
+
+[tool]
+display_name = "OpenClaw"
+config_key = "openclaw"
+description = "Open-source AI coding assistant and multi-channel local gateway"
+homepage = "https://openclaw.ai/"
+documentation = "https://docs.openclaw.ai/"
+cli_command = "openclaw"
+requires_npm = true
+requires_sudo = false
+status = "experimental"
+
+[tool.install]
+command = "npm"
+args = ["install", "-g", "openclaw"]
+verify_command = "openclaw --version"
+post_install_message = "OpenClaw installed successfully! Run 'openclaw onboard' or 'openclaw setup' to configure providers and gateway settings."
+
+[tool.update]
+command = "openclaw"
+args = ["update", "--yes", "--no-restart"]
+verify_command = "openclaw --version"
+
+[tool.auth]
+env_vars = ["OPENROUTER_API_KEY"]
+setup_url = "https://docs.openclaw.ai/"
+browser_auth = true
+auth_instructions = "Run 'openclaw onboard' to configure providers. For headless OpenRouter setup, use 'openclaw onboard --auth-choice openrouter-api-key'. OpenClaw can manage local gateway services, ports, webhooks, and token storage, so review gateway and provider settings before enabling persistent services."
+auth_mode = "any"
+default_env_var = "OPENROUTER_API_KEY"
+cli_auth_command = "openclaw onboard"
+providers = [
+    {name = "OpenRouter", env_var = "OPENROUTER_API_KEY", key_hint = "sk-or-*", setup_url = "https://openrouter.ai/keys"},
+]
+
+[tool.features]
+supports_files = true
+supports_streaming = true
+supports_conversation = true
+max_context_tokens = 200000
+supported_languages = ["all"]

--- a/npm/terminal-jarvis/config/tools/pi.toml
+++ b/npm/terminal-jarvis/config/tools/pi.toml
@@ -6,8 +6,8 @@
 display_name = "Pi"
 config_key = "pi"
 description = "Terminal-based coding agent"
-homepage = "https://github.com/mariozechner/pi-coding-agent"
-documentation = "https://github.com/mariozechner/pi-coding-agent"
+homepage = "https://github.com/earendil-works/pi-mono"
+documentation = "https://github.com/earendil-works/pi-mono"
 cli_command = "pi"
 requires_npm = true
 requires_sudo = false
@@ -15,13 +15,13 @@ status = "experimental"
 
 [tool.install]
 command = "npm"
-args = ["install", "-g", "@mariozechner/pi-coding-agent"]
+args = ["install", "-g", "@earendil-works/pi-coding-agent"]
 verify_command = "pi --version"
 post_install_message = "Pi installed!"
 
 [tool.update]
 command = "npm"
-args = ["update", "-g", "@mariozechner/pi-coding-agent"]
+args = ["update", "-g", "@earendil-works/pi-coding-agent"]
 verify_command = "pi --version"
 
 [tool.auth]

--- a/npm/terminal-jarvis/package-lock.json
+++ b/npm/terminal-jarvis/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terminal-jarvis",
-      "version": "0.0.80",
+      "version": "0.0.81",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -130,9 +130,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -150,9 +147,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -170,9 +164,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -190,9 +181,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -784,9 +772,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -801,9 +786,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -818,9 +800,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -835,9 +814,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -852,9 +828,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -869,9 +842,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -886,9 +856,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -903,9 +870,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -920,9 +884,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -937,9 +898,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -954,9 +912,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -971,9 +926,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -988,9 +940,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/npm/terminal-jarvis/package.json
+++ b/npm/terminal-jarvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "description": "AI Coding Tools Wrapper - Unified interface for claude-code, gemini-cli, qwen-code, opencode, llxprt, codex, crush, goose, amp, and aider",
   "bin": {
     "terminal-jarvis": "bin/terminal-jarvis"

--- a/src/cli_logic/cli_logic_update_operations.rs
+++ b/src/cli_logic/cli_logic_update_operations.rs
@@ -161,10 +161,11 @@ fn command_failure_message(
     }
 }
 
-/// Truncate a string to a maximum length, appending ellipsis if needed
+/// Truncate a string to a maximum length, appending ellipsis if needed.
+/// Uses char-boundaries to avoid panicking on multi-byte UTF-8 codepoints.
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() > max {
-        format!("{}...", &s[..max])
+    if s.chars().count() > max {
+        s.chars().take(max).collect::<String>() + "..."
     } else {
         s.to_string()
     }

--- a/src/cli_logic/cli_logic_update_operations.rs
+++ b/src/cli_logic/cli_logic_update_operations.rs
@@ -5,12 +5,10 @@
 
 use crate::installation_arguments::InstallationManager;
 use crate::progress_utils::{ProgressContext, ProgressUtils};
+use crate::tools::ToolManager;
 use anyhow::{anyhow, Result};
-use std::collections::HashMap;
 use std::io::{self, Write};
-use std::time::Duration;
 use tokio::process::Command as AsyncCommand;
-use tokio::task::JoinSet;
 
 /// Handle updating packages - either a specific package or all packages
 pub async fn handle_update_packages(package: Option<&str>) -> Result<()> {
@@ -42,110 +40,125 @@ async fn update_single_package(pkg: &str) -> Result<()> {
     }
 }
 
-/// Update all packages concurrently with minimal, non-animated feedback
+/// Update all installed packages with deterministic, non-animated feedback
 async fn update_all_packages() -> Result<()> {
-    let tools = InstallationManager::get_tool_names();
+    let tools = selected_update_tools(ToolManager::get_installed_tools());
     if tools.is_empty() {
-        ProgressUtils::info_message("No tools to update");
+        ProgressUtils::info_message("No installed tools to update");
         return Ok(());
     }
 
     let total = tools.len();
+    let headless = crate::cli_logic::cli_logic_headless::is_headless();
 
-    println!("\nUpdating {total} tools concurrently...");
+    if headless {
+        println!("[INFO] Updating installed tools: {total} found");
+    } else {
+        println!("\nUpdating installed tools: {total} found");
+    }
 
-    // Compute fixed column widths for consistent alignment
-    let idx_width = total.to_string().len().max(2); // width for the left index
-    let name_width = tools.iter().map(|t| t.len()).max().unwrap_or(0).max(8);
-
-    // Map tool -> index for quick updates
-    let mut index_map: HashMap<String, usize> = HashMap::new();
-
-    // Print all lines upfront with DOWNLOADING state
+    let mut results = Vec::with_capacity(total);
     for (i, tool) in tools.iter().enumerate() {
-        index_map.insert(tool.clone(), i);
-        println!(
-            "[{:>idx$}/{}]  {:<name$}  DOWNLOADING",
-            i + 1,
-            total,
-            tool,
-            idx = idx_width,
-            name = name_width
-        );
-    }
-    let _ = io::stdout().flush();
-
-    // Helper to update a single printed line in-place
-    let update_line = |tool_index: usize, status: &str| {
-        let lines_up = total - tool_index; // from one line below the last entry
-                                           // Build the updated line text
-        let line_text = format!(
-            "[{:>idx$}/{}]  {:<name$}  {}",
-            tool_index + 1,
-            total,
-            tools[tool_index],
-            status,
-            idx = idx_width,
-            name = name_width
-        );
-        // Move up, clear line, write, move back down
-        print!("\x1b[{lines_up}A");
-        print!("\r\x1b[2K{line_text}");
-        print!("\x1b[{lines_up}B\r");
+        let position = i + 1;
+        println!("[{position}/{total}] {tool} UPDATE start");
+        let result = update_tool_using_install_manager(tool).await;
+        match &result {
+            Ok(()) => println!("[{position}/{total}] {tool} UPDATE ok"),
+            Err(err) => println!(
+                "[{position}/{total}] {tool} UPDATE failed: {}",
+                truncate(&err.to_string(), 200)
+            ),
+        }
+        results.push((tool.clone(), result));
         let _ = io::stdout().flush();
-    };
-
-    // Spawn all updates after printing lines to ensure they show immediately
-    let mut join_set: JoinSet<(String, Result<()>)> = JoinSet::new();
-    for (i, tool) in tools.iter().cloned().enumerate() {
-        join_set.spawn(async move {
-            tokio::time::sleep(Duration::from_millis((i as u64) * 50)).await;
-            let res = update_tool_using_install_manager(&tool).await;
-            (tool, res)
-        });
     }
 
-    let mut ok_count: usize = 0;
-    let mut fail_count: usize = 0;
-    let mut failures: Vec<(String, String)> = Vec::new();
+    summarize_update_results(results)
+}
 
-    while let Some(join_res) = join_set.join_next().await {
-        match join_res {
-            Ok((tool, Ok(()))) => {
-                ok_count += 1;
-                if let Some(&idx) = index_map.get(&tool) {
-                    update_line(idx, "DONE");
-                }
-            }
-            Ok((tool, Err(e))) => {
-                fail_count += 1;
-                let msg = truncate(&e.to_string(), 80);
-                if let Some(&idx) = index_map.get(&tool) {
-                    update_line(idx, "FAILED");
-                }
-                failures.push((tool, msg));
-            }
-            Err(e) => {
-                fail_count += 1;
-                let msg = truncate(&format!("join error: {e}"), 80);
-                // We cannot map to a specific line, so append failure list only
-                failures.push(("<task>".to_string(), msg));
-            }
+fn selected_update_tools(mut installed_tools: Vec<String>) -> Vec<String> {
+    installed_tools.sort();
+    installed_tools.dedup();
+    installed_tools
+        .into_iter()
+        .filter(|tool| InstallationManager::get_update_command(tool).is_some())
+        .collect()
+}
+
+fn summarize_update_results(results: Vec<(String, Result<()>)>) -> Result<()> {
+    let mut ok_count = 0;
+    let mut failures = Vec::new();
+
+    for (tool, result) in results {
+        match result {
+            Ok(()) => ok_count += 1,
+            Err(err) => failures.push((tool, err.to_string())),
         }
     }
 
-    // Compact final status
-    println!("\nUpdate complete: {ok_count} OK, {fail_count} FAIL");
-    if !failures.is_empty() {
-        println!("Failures:");
-        for (tool, msg) in failures {
-            println!("- {tool}: {msg}");
+    let fail_count = failures.len();
+    if fail_count == 0 {
+        println!("[INFO] Update complete: {ok_count} OK, 0 FAIL");
+        return Ok(());
+    }
+
+    eprintln!("[ERROR] Update complete: {ok_count} OK, {fail_count} FAIL");
+    eprintln!("Failures:");
+    for (tool, msg) in failures {
+        eprintln!("- {tool}: {}", truncate(&msg, 200));
+    }
+
+    Err(anyhow!(
+        "Update failed for {fail_count} tool{}",
+        if fail_count == 1 { "" } else { "s" }
+    ))
+}
+
+fn resolve_update_command(
+    tool_name: &str,
+) -> Result<crate::installation_arguments::InstallCommand> {
+    InstallationManager::get_update_command(tool_name)
+        .ok_or_else(|| anyhow!("Tool '{tool_name}' not found in configuration"))
+}
+
+fn command_display(command: &crate::installation_arguments::InstallCommand) -> String {
+    if command.args.is_empty() {
+        command.command.clone()
+    } else {
+        format!("{} {}", command.command, command.args.join(" "))
+    }
+}
+
+fn command_failure_message(
+    command: &crate::installation_arguments::InstallCommand,
+    output: &std::process::Output,
+) -> String {
+    let code = output.status.code().unwrap_or(-1);
+    let mut details = String::new();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr.trim();
+    if !stderr.is_empty() {
+        details.push_str(stderr);
+    }
+
+    if details.is_empty() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stdout = stdout.trim();
+        if !stdout.is_empty() {
+            details.push_str(stdout);
         }
     }
-    // Ensure we end on a clean new line and flush, so follow-up prompts work reliably
-    let _ = io::stdout().flush();
 
-    Ok(())
+    if details.is_empty() {
+        format!("{} exited {code}", command.command)
+    } else {
+        format!(
+            "{} exited {code}: {}",
+            command.command,
+            truncate(&details, 200)
+        )
+    }
 }
 
 /// Truncate a string to a maximum length, appending ellipsis if needed
@@ -159,49 +172,17 @@ fn truncate(s: &str, max: usize) -> String {
 
 /// Update a tool using the InstallationManager configuration
 async fn update_tool_using_install_manager(tool_name: &str) -> Result<()> {
-    let install_commands = InstallationManager::get_install_commands();
-
-    let install_info = install_commands
-        .get(tool_name)
-        .ok_or_else(|| anyhow!("Tool '{tool_name}' not found in configuration"))?;
-
-    // Convert install command to update command
-    let update_command =
-        if install_info.command == "npm" && install_info.args.contains(&"install".to_string()) {
-            // Convert npm install to npm update and remove version specifiers
-            let mut update_args = Vec::new();
-            for arg in &install_info.args {
-                if arg == "install" {
-                    update_args.push("update".to_string());
-                } else if arg.contains("@latest") {
-                    // Remove @latest from package names
-                    // Examples:
-                    // @qwen-code/qwen-code@latest -> @qwen-code/qwen-code
-                    // opencode-ai@latest -> opencode-ai
-                    let package_name = arg.replace("@latest", "");
-                    update_args.push(package_name);
-                } else {
-                    update_args.push(arg.clone());
-                }
-            }
-            format!("{} {}", install_info.command, update_args.join(" "))
-        } else {
-            // For non-npm commands, use the install command as-is
-            format!("{} {}", install_info.command, install_info.args.join(" "))
-        };
-
+    let update_command = resolve_update_command(tool_name)?;
     execute_command(&update_command).await
 }
 
 /// Execute a shell command
-async fn execute_command(command: &str) -> Result<()> {
-    let mut parts = command.split_whitespace();
-    let cmd = parts.next().ok_or_else(|| anyhow!("Empty command"))?;
-    let args: Vec<&str> = parts.collect();
+async fn execute_command(command: &crate::installation_arguments::InstallCommand) -> Result<()> {
+    if command.command.trim().is_empty() {
+        return Err(anyhow!("Empty command"));
+    }
 
-    // For npm global updates, try with sudo if available to handle permission issues
-    let status = if cmd == "npm" && args.contains(&"-g") {
-        // Check if sudo is available
+    let output = if command.requires_sudo {
         let sudo_available = std::process::Command::new("which")
             .arg("sudo")
             .output()
@@ -210,52 +191,80 @@ async fn execute_command(command: &str) -> Result<()> {
 
         if sudo_available {
             let mut sudo_cmd = AsyncCommand::new("sudo");
-            // Non-interactive sudo to avoid blocking on password prompts
             sudo_cmd.arg("-n");
-            sudo_cmd.arg(cmd);
-            sudo_cmd.args(&args);
-            // Ensure child doesn't read stdin; we suppress all IO
+            sudo_cmd.arg(&command.command);
+            sudo_cmd.args(&command.args);
             sudo_cmd.stdin(std::process::Stdio::null());
-            sudo_cmd.stdout(std::process::Stdio::null());
-            sudo_cmd.stderr(std::process::Stdio::null());
-            let status = sudo_cmd.status().await?;
-            if status.success() {
-                status
-            } else {
-                // Fallback to running without sudo to avoid interactive password prompts
-                let mut regular_cmd = AsyncCommand::new(cmd);
-                regular_cmd.args(&args);
-                regular_cmd.stdin(std::process::Stdio::null());
-                regular_cmd.stdout(std::process::Stdio::null());
-                regular_cmd.stderr(std::process::Stdio::null());
-                regular_cmd.status().await?
-            }
+            sudo_cmd.output().await?
         } else {
-            // Fallback to regular command if sudo isn't available
-            let mut regular_cmd = AsyncCommand::new(cmd);
-            regular_cmd.args(&args);
+            let mut regular_cmd = AsyncCommand::new(&command.command);
+            regular_cmd.args(&command.args);
             regular_cmd.stdin(std::process::Stdio::null());
-            regular_cmd.stdout(std::process::Stdio::null());
-            regular_cmd.stderr(std::process::Stdio::null());
-            regular_cmd.status().await?
+            regular_cmd.output().await?
         }
     } else {
-        // Non-global npm commands or other commands
-        let mut regular_cmd = AsyncCommand::new(cmd);
-        regular_cmd.args(&args);
+        let mut regular_cmd = AsyncCommand::new(&command.command);
+        regular_cmd.args(&command.args);
         regular_cmd.stdin(std::process::Stdio::null());
-        regular_cmd.stdout(std::process::Stdio::null());
-        regular_cmd.stderr(std::process::Stdio::null());
-        regular_cmd.status().await?
+        regular_cmd.output().await?
     };
 
-    if !status.success() {
+    if !output.status.success() {
         return Err(anyhow!(
-            "Command '{}' failed with exit code: {}",
-            command,
-            status.code().unwrap_or(-1)
+            "Command '{}' failed: {}",
+            command_display(command),
+            command_failure_message(command, &output)
         ));
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selected_update_tools_uses_installed_tools_only() {
+        let selected = selected_update_tools(vec![
+            "codex".to_string(),
+            "claude".to_string(),
+            "codex".to_string(),
+            "__unknown__".to_string(),
+        ]);
+
+        assert_eq!(selected, vec!["claude".to_string(), "codex".to_string()]);
+        assert!(selected.len() < InstallationManager::get_tool_names().len());
+    }
+
+    #[test]
+    fn resolve_update_command_uses_tool_update_config() {
+        let command = resolve_update_command("claude").expect("claude has update config");
+
+        assert_eq!(command.command, "claude");
+        assert_eq!(command.args, vec!["update".to_string()]);
+        assert_ne!(command.command, "curl");
+    }
+
+    #[test]
+    fn resolve_update_command_unknown_tool_fails_clearly() {
+        let err = resolve_update_command("__missing_tool__").unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Tool '__missing_tool__' not found in configuration"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn aggregate_update_failure_returns_error() {
+        let result = summarize_update_results(vec![
+            ("claude".to_string(), Ok(())),
+            ("codex".to_string(), Err(anyhow!("npm exited 1"))),
+        ]);
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("1 tool"));
+    }
 }

--- a/src/security/credential_encryption.rs
+++ b/src/security/credential_encryption.rs
@@ -253,9 +253,24 @@ impl CredentialEncryption {
             .encrypt(nonce, plaintext.as_ref())
             .map_err(|e| anyhow!("Encryption failed: {:?}", e))?;
 
+        // Preserve existing salt so future decryption can re-derive the same key.
+        // If no store exists yet, generate a fresh random salt.
+        let salt = if let Ok(encoded) = fs::read(&path) {
+            if let Ok(existing) = serde_json::from_slice::<EncryptedCredentialStore>(&encoded) {
+                existing.salt
+            } else {
+                let mut salt = [0u8; 32];
+                rand::thread_rng().fill_bytes(&mut salt);
+                salt.to_vec()
+            }
+        } else {
+            let mut salt = [0u8; 32];
+            rand::thread_rng().fill_bytes(&mut salt);
+            salt.to_vec()
+        };
+
         let store = EncryptedCredentialStore::new(
-            // Use existing salt or generate new
-            vec![0u8; 32],
+            salt,
             nonce_bytes.to_vec(),
             ciphertext,
             tools.keys().cloned().collect(),

--- a/tests/fixtures/tool_registry_expectations.toml
+++ b/tests/fixtures/tool_registry_expectations.toml
@@ -45,25 +45,23 @@ expected_npm_package = "@vybestack/llxprt-code"
 expected_bin = "llxprt"
 
 [tools.nanocoder]
-expected_npm_package = "@motesoftware/nanocoder"
+expected_npm_package = "@nanocollective/nanocoder"
 expected_bin = "nanocoder"
+
+[tools.openclaw]
+expected_npm_package = "openclaw"
+expected_bin = "openclaw"
 
 [tools.opencode]
 expected_npm_package = "opencode-ai"
 expected_bin = "opencode"
 
 [tools.pi]
-expected_npm_package = "@mariozechner/pi-coding-agent"
+expected_npm_package = "@earendil-works/pi-coding-agent"
 expected_bin = "pi"
 
 [tools.qwen]
 expected_npm_package = "@qwen-code/qwen-code"
 expected_bin = "qwen"
 
-[deprecated_packages."@motesoftware/nanocoder"]
-replacement = "@nanocollective/nanocoder"
-temporary_allow_reason = "Known catalog drift; keep visible until the dedicated cleanup PR updates nanocoder metadata."
 
-[deprecated_packages."@mariozechner/pi-coding-agent"]
-replacement = "@earendil-works/pi-coding-agent"
-temporary_allow_reason = "Known catalog drift; keep visible until the dedicated cleanup PR updates pi metadata."

--- a/tests/fixtures/tool_registry_expectations.toml
+++ b/tests/fixtures/tool_registry_expectations.toml
@@ -1,0 +1,69 @@
+[tools.amp]
+expected_npm_package = "@sourcegraph/amp"
+expected_bin = "amp"
+
+[tools.code]
+expected_npm_package = "@just-every/code"
+expected_bin = "coder"
+allowed_bin_mismatch_reason = "Current catalog uses code, but the npm package exposes coder; tracked for drift cleanup."
+known_collision = "code collides with the Visual Studio Code CLI; do not use without an explicit compatibility decision."
+
+[tools.codex]
+expected_npm_package = "@openai/codex"
+expected_bin = "codex"
+
+[tools.copilot]
+expected_npm_package = "@github/copilot"
+expected_bin = "copilot"
+
+[tools.crush]
+expected_npm_package = "@charmland/crush"
+expected_bin = "crush"
+
+[tools.forge]
+expected_npm_package = "forgecode"
+expected_bin = "forge"
+
+[tools.gemini]
+expected_npm_package = "@google/gemini-cli"
+expected_bin = "gemini"
+
+[tools.jules]
+expected_npm_package = "@google/jules"
+expected_bin = "jules"
+
+[tools.kilocode]
+expected_npm_package = "@kilocode/cli"
+expected_bin = "kilocode"
+
+[tools.letta]
+expected_npm_package = "@letta-ai/letta-code"
+expected_bin = "letta"
+
+[tools.llxprt]
+expected_npm_package = "@vybestack/llxprt-code"
+expected_bin = "llxprt"
+
+[tools.nanocoder]
+expected_npm_package = "@motesoftware/nanocoder"
+expected_bin = "nanocoder"
+
+[tools.opencode]
+expected_npm_package = "opencode-ai"
+expected_bin = "opencode"
+
+[tools.pi]
+expected_npm_package = "@mariozechner/pi-coding-agent"
+expected_bin = "pi"
+
+[tools.qwen]
+expected_npm_package = "@qwen-code/qwen-code"
+expected_bin = "qwen"
+
+[deprecated_packages."@motesoftware/nanocoder"]
+replacement = "@nanocollective/nanocoder"
+temporary_allow_reason = "Known catalog drift; keep visible until the dedicated cleanup PR updates nanocoder metadata."
+
+[deprecated_packages."@mariozechner/pi-coding-agent"]
+replacement = "@earendil-works/pi-coding-agent"
+temporary_allow_reason = "Known catalog drift; keep visible until the dedicated cleanup PR updates pi metadata."

--- a/tests/fixtures/tool_registry_expectations.toml
+++ b/tests/fixtures/tool_registry_expectations.toml
@@ -5,8 +5,6 @@ expected_bin = "amp"
 [tools.code]
 expected_npm_package = "@just-every/code"
 expected_bin = "coder"
-allowed_bin_mismatch_reason = "Current catalog uses code, but the npm package exposes coder; tracked for drift cleanup."
-known_collision = "code collides with the Visual Studio Code CLI; do not use without an explicit compatibility decision."
 
 [tools.codex]
 expected_npm_package = "@openai/codex"

--- a/tests/tool_catalog_validation_tests.rs
+++ b/tests/tool_catalog_validation_tests.rs
@@ -1,0 +1,254 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use terminal_jarvis::tools::tools_config::ToolDefinition;
+
+#[derive(Debug, Deserialize)]
+struct ToolFile {
+    tool: ToolDefinition,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryExpectations {
+    #[serde(default)]
+    tools: HashMap<String, ToolExpectation>,
+    #[serde(default)]
+    deprecated_packages: HashMap<String, DeprecatedPackage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolExpectation {
+    expected_npm_package: Option<String>,
+    expected_bin: Option<String>,
+    known_collision: Option<String>,
+    allowed_bin_mismatch_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeprecatedPackage {
+    replacement: String,
+    temporary_allow_reason: Option<String>,
+}
+
+fn load_tool_configs() -> Vec<(String, PathBuf, ToolDefinition)> {
+    let mut configs = Vec::new();
+
+    for entry in fs::read_dir("config/tools").expect("config/tools must be readable") {
+        let entry = entry.expect("config/tools entry must be readable");
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("toml") {
+            continue;
+        }
+
+        let content = fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("{} must be readable: {err}", path.display()));
+        let parsed: ToolFile = toml::from_str(&content)
+            .unwrap_or_else(|err| panic!("{} must parse as a tool config: {err}", path.display()));
+        let tool_name = path
+            .file_stem()
+            .and_then(|name| name.to_str())
+            .expect("tool config filename must be UTF-8")
+            .to_string();
+
+        configs.push((tool_name, path, parsed.tool));
+    }
+
+    configs.sort_by(|left, right| left.0.cmp(&right.0));
+    configs
+}
+
+fn load_expectations() -> RegistryExpectations {
+    let content = fs::read_to_string("tests/fixtures/tool_registry_expectations.toml")
+        .expect("tool registry expectations fixture must be readable");
+    toml::from_str(&content).expect("tool registry expectations fixture must parse")
+}
+
+fn assert_non_empty(value: &str, label: &str, path: &Path) {
+    assert!(
+        !value.trim().is_empty(),
+        "{label} must be set in {}",
+        path.display()
+    );
+}
+
+fn npm_package_from_args(args: &[String]) -> Option<&str> {
+    args.iter()
+        .rev()
+        .find(|arg| !arg.starts_with('-') && arg.as_str() != "install" && arg.as_str() != "update")
+        .map(String::as_str)
+}
+
+fn normalize_npm_package(package: &str) -> &str {
+    package.strip_suffix("@latest").unwrap_or(package)
+}
+
+#[test]
+fn tool_catalog_configs_parse_and_define_required_commands() {
+    let configs = load_tool_configs();
+    assert!(
+        !configs.is_empty(),
+        "tool catalog must not be empty; expected config/tools/*.toml"
+    );
+
+    for (tool_name, path, tool) in configs {
+        assert_eq!(
+            tool.config_key,
+            tool_name,
+            "tool.config_key must match the filename for {}",
+            path.display()
+        );
+
+        assert_non_empty(&tool.display_name, "display_name", &path);
+        assert_non_empty(&tool.description, "description", &path);
+        assert_non_empty(&tool.cli_command, "cli_command", &path);
+
+        assert_non_empty(&tool.install.command, "tool.install.command", &path);
+        assert!(
+            !tool.install.args.is_empty() || tool.install.pipe_to.is_some(),
+            "tool.install must have args or pipe_to in {}",
+            path.display()
+        );
+        assert_non_empty(
+            tool.install.verify_command.as_deref().unwrap_or_default(),
+            "tool.install.verify_command",
+            &path,
+        );
+
+        assert_non_empty(&tool.update.command, "tool.update.command", &path);
+        assert!(
+            !tool.update.args.is_empty() || tool.update.pipe_to.is_some(),
+            "tool.update must have args or pipe_to in {}",
+            path.display()
+        );
+        assert_non_empty(
+            tool.update.verify_command.as_deref().unwrap_or_default(),
+            "tool.update.verify_command",
+            &path,
+        );
+    }
+}
+
+#[test]
+fn tool_catalog_update_commands_are_non_interactive() {
+    let configs = load_tool_configs();
+    let interactive_tokens = ["login", "auth", "configure", "wizard", "prompt"];
+
+    for (tool_name, path, tool) in configs {
+        let mut update_parts = vec![tool.update.command.as_str()];
+        update_parts.extend(tool.update.args.iter().map(String::as_str));
+        if let Some(pipe_to) = tool.update.pipe_to.as_deref() {
+            update_parts.push(pipe_to);
+        }
+
+        for part in update_parts {
+            assert!(
+                !interactive_tokens.contains(&part),
+                "tool.update for '{tool_name}' appears interactive in {}: token '{part}'",
+                path.display()
+            );
+        }
+    }
+}
+
+#[test]
+fn tool_catalog_known_cli_collisions_are_explicitly_documented() {
+    let configs = load_tool_configs();
+    let expectations = load_expectations();
+    let known_collisions = ["code", "cursor"];
+
+    for (tool_name, path, tool) in configs {
+        if known_collisions.contains(&tool.cli_command.as_str()) {
+            let collision_reason = expectations
+                .tools
+                .get(&tool_name)
+                .and_then(|expectation| expectation.known_collision.as_deref())
+                .unwrap_or_default();
+
+            assert!(
+                !collision_reason.trim().is_empty(),
+                "cli_command '{}' in {} is a known collision and needs an explicit fixture reason",
+                tool.cli_command,
+                path.display()
+            );
+        }
+    }
+}
+
+#[test]
+fn tool_catalog_npm_expectations_match_install_and_cli_metadata() {
+    let configs = load_tool_configs();
+    let expectations = load_expectations();
+
+    for (tool_name, path, tool) in configs {
+        if !tool.requires_npm {
+            continue;
+        }
+
+        let package = npm_package_from_args(&tool.install.args)
+            .unwrap_or_else(|| panic!("npm tool '{tool_name}' must install a package"));
+        let normalized_package = normalize_npm_package(package);
+        let expectation = expectations.tools.get(&tool_name).unwrap_or_else(|| {
+            panic!(
+                "npm tool '{tool_name}' needs an expectation in tests/fixtures/tool_registry_expectations.toml"
+            )
+        });
+
+        if let Some(expected_package) = expectation.expected_npm_package.as_deref() {
+            assert_eq!(
+                normalized_package,
+                expected_package,
+                "npm package mismatch in {}",
+                path.display()
+            );
+        }
+
+        if let Some(expected_bin) = expectation.expected_bin.as_deref() {
+            if tool.cli_command != expected_bin {
+                let reason = expectation
+                    .allowed_bin_mismatch_reason
+                    .as_deref()
+                    .unwrap_or_default();
+                assert!(
+                    !reason.trim().is_empty(),
+                    "cli_command '{}' in {} does not match expected npm bin '{expected_bin}' and needs an explicit fixture reason",
+                    tool.cli_command,
+                    path.display()
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn tool_catalog_deprecated_npm_packages_are_visible_until_cleaned_up() {
+    let configs = load_tool_configs();
+    let expectations = load_expectations();
+
+    for (tool_name, path, tool) in configs {
+        if !tool.requires_npm {
+            continue;
+        }
+
+        let package = npm_package_from_args(&tool.install.args)
+            .unwrap_or_else(|| panic!("npm tool '{tool_name}' must install a package"));
+        let normalized_package = normalize_npm_package(package);
+
+        if let Some(deprecated) = expectations.deprecated_packages.get(normalized_package) {
+            assert!(
+                !deprecated.replacement.trim().is_empty(),
+                "deprecated package '{normalized_package}' in {} must document its replacement",
+                path.display()
+            );
+            assert!(
+                deprecated
+                    .temporary_allow_reason
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("cleanup"),
+                "deprecated package '{normalized_package}' in {} needs a temporary cleanup reason",
+                path.display()
+            );
+        }
+    }
+}

--- a/tests/tool_installation_detection_tests.rs
+++ b/tests/tool_installation_detection_tests.rs
@@ -8,6 +8,7 @@
 //   - Tool detection must fall back to shell environment and ~/.local/bin
 
 use terminal_jarvis::installation_arguments::InstallationManager;
+use terminal_jarvis::tools::tools_command_mapping::{get_cli_command, get_update_command};
 
 // ---------------------------------------------------------------------------
 // Install command correctness
@@ -86,6 +87,18 @@ fn test_npm_tool_package_names_are_correct() {
             tool: "codex",
             expected_pkg: "@openai/codex",
         },
+        Case {
+            tool: "code",
+            expected_pkg: "@just-every/code",
+        },
+        Case {
+            tool: "nanocoder",
+            expected_pkg: "@nanocollective/nanocoder",
+        },
+        Case {
+            tool: "pi",
+            expected_pkg: "@earendil-works/pi-coding-agent",
+        },
     ];
 
     for case in &cases {
@@ -98,6 +111,40 @@ fn test_npm_tool_package_names_are_correct() {
             );
         }
     }
+}
+
+/// Update commands must use the same package identity as install commands.
+#[test]
+fn test_npm_tool_update_package_names_are_correct() {
+    for tool in ["code", "nanocoder", "pi"] {
+        let install_cmd = InstallationManager::get_install_command(tool)
+            .expect("tool must be in the tool registry");
+        let update_cmd = get_update_command(tool).expect("tool must have an update command");
+
+        let install_pkg = install_cmd
+            .args
+            .last()
+            .expect("install command must include a package");
+        let update_pkg = update_cmd
+            .args
+            .last()
+            .expect("update command must include a package");
+
+        assert_eq!(
+            update_pkg, install_pkg,
+            "Tool '{tool}' update package must match install package"
+        );
+    }
+}
+
+/// @just-every/code exposes the `coder` binary; `code` is commonly VS Code.
+#[test]
+fn test_code_uses_coder_binary() {
+    assert_eq!(
+        get_cli_command("code"),
+        "coder",
+        "@just-every/code must launch the upstream `coder` binary"
+    );
 }
 
 /// NPM tools must not require sudo (NVM users lack system npm in sudo PATH).

--- a/tests/tool_installation_detection_tests.rs
+++ b/tests/tool_installation_detection_tests.rs
@@ -86,6 +86,10 @@ fn test_npm_tool_package_names_are_correct() {
             tool: "codex",
             expected_pkg: "@openai/codex",
         },
+        Case {
+            tool: "openclaw",
+            expected_pkg: "openclaw",
+        },
     ];
 
     for case in &cases {
@@ -210,4 +214,57 @@ fn test_goose_install_uses_curl_not_pip() {
         !cmd.requires_npm,
         "goose must not require npm - it uses a curl-based installer"
     );
+}
+
+#[test]
+fn test_openclaw_catalog_metadata() {
+    use terminal_jarvis::tools::tools_command_mapping::get_cli_command;
+
+    let install_cmd = InstallationManager::get_install_command("openclaw")
+        .expect("openclaw must be in the tool registry");
+    assert_eq!(install_cmd.command, "npm");
+    assert_eq!(install_cmd.args, ["install", "-g", "openclaw"]);
+    assert!(install_cmd.requires_npm);
+    assert!(
+        !install_cmd.requires_sudo,
+        "openclaw uses npm and must not require sudo"
+    );
+
+    let update_cmd = InstallationManager::get_update_command("openclaw")
+        .expect("openclaw must have an update command");
+    assert_eq!(update_cmd.command, "openclaw");
+    assert_eq!(update_cmd.args, ["update", "--yes", "--no-restart"]);
+
+    assert_eq!(get_cli_command("openclaw"), "openclaw");
+}
+
+#[test]
+fn test_hermes_catalog_metadata() {
+    use terminal_jarvis::tools::tools_command_mapping::get_cli_command;
+
+    let install_cmd = InstallationManager::get_install_command("hermes")
+        .expect("hermes must be in the tool registry");
+    assert_eq!(install_cmd.command, "bash");
+    assert!(
+        install_cmd
+            .args
+            .iter()
+            .any(|arg| arg.contains("--skip-setup")),
+        "hermes install should skip the interactive setup wizard"
+    );
+    assert!(
+        !install_cmd.requires_npm,
+        "hermes installer manages its own runtime dependencies"
+    );
+    assert!(
+        !install_cmd.requires_sudo,
+        "hermes per-user install must not require sudo"
+    );
+
+    let update_cmd = InstallationManager::get_update_command("hermes")
+        .expect("hermes must have an update command");
+    assert_eq!(update_cmd.command, "hermes");
+    assert_eq!(update_cmd.args, ["update"]);
+
+    assert_eq!(get_cli_command("hermes"), "hermes");
 }


### PR DESCRIPTION
## Summary

Integrates all isolated task branches (A-E) into develop and prepares release 0.0.81.

## Integrated Changes

- **Option A** (fix/headless-update-all): Headless update-all installed-only behavior
- **Option B** (test/tool-catalog-validation): Offline tool catalog validation tests
- **Option C** (fix/tool-catalog-drift): Corrected Code/Nanocoder/Pi package metadata
- **Option D** (feat/add-hermes-openclaw): Hermes Agent and OpenClaw catalog entries
- **Option E** (fix/security-docs-release-hygiene): Restored SECURITY.md and fixed README counts

## Release Prep

- Version bumped to 0.0.81 across Cargo.toml, package.json, package-lock.json
- Homebrew Formula updated to v0.0.81 release URLs
- CHANGELOG.md updated with 0.0.81 entry

## Known Issue

-  has a pre-existing unrelated failure. Per handoff guidance, this is only a release blocker if CI flags it as a new regression or if requested by maintainer.

---
*This PR was prepared per AGENTS.md release ordering: CHANGELOG before deployment scripts, Homebrew Formula before GitHub release, version sync across platforms.*