### PR TITLE
ci(security): upload grype sarif results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,7 @@ jobs:
   security-general:
     name: Security - General
     permissions:
+      actions: read
       contents: read
       security-events: write
     runs-on: ubuntu-latest
@@ -295,9 +296,22 @@ jobs:
         output-format: sarif
         cache-db: true
 
-    - name: Check scan results
+    - name: Validate Anchore SARIF output
       run: |
-        if [ -f results.sarif ]; then
-          echo "Scan complete. Review SARIF output for details."
-          # SARIF upload disabled due to parsing issues - review artifacts manually
+        set -euo pipefail
+        sarif_file="${{ steps.anchore.outputs.sarif }}"
+        if [ -z "$sarif_file" ]; then
+          echo "Anchore did not report a SARIF output path."
+          exit 1
         fi
+        if [ ! -s "$sarif_file" ]; then
+          echo "Anchore SARIF output is missing or empty: $sarif_file"
+          exit 1
+        fi
+        echo "Anchore SARIF output is ready for upload: $sarif_file"
+
+    - name: Upload Anchore SARIF report
+      uses: github/codeql-action/upload-sarif@v4
+      with:
+        sarif_file: ${{ steps.anchore.outputs.sarif }}
+        category: security-general

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,12 @@ Max turns: 5 (`maxToolLoops`). Sequential tool execution.
 ## Deployment
 
 - Local: `./scripts/cicd/local-ci.sh` then push to develop
-- CI/CD: Push to develop triggers GitHub Actions
+- CI: Push to develop triggers GitHub Actions (`.github/workflows/ci.yml`)
+- **CD/Release: Push a `v*` tag triggers `.github/workflows/cd-multiplatform.yml`**
+  - Builds binaries for macOS (x86_64, aarch64) and Linux (x86_64, aarch64)
+  - Publishes to crates.io (requires `CARGO_REGISTRY_TOKEN` secret)
+  - Creates GitHub release with all binary assets
+  - Updates `homebrew-terminal-jarvis` Formula automatically
 - Version only: `./scripts/cicd/local-cd.sh --update-version X.X.X`
 
 ## Cross-Repo
@@ -57,9 +62,16 @@ Max turns: 5 (`maxToolLoops`). Sequential tool execution.
 
 1. Update CHANGELOG.md
 2. Update version in Cargo.toml, package.json, homebrew/Formula
-3. Run verify-change.sh
-4. Push to develop
-5. Monitor CI/CD pipeline
+3. Run verify-change.sh (or rely on CI green status)
+4. Push to develop via PR
+5. Ensure CI on develop is green
+6. **Push version tag** (`git tag vX.X.X && git push origin vX.X.X`)
+   - Triggers `.github/workflows/cd-multiplatform.yml`
+   - CI builds multi-platform binaries, publishes to crates.io,
+     creates GitHub release, and updates `homebrew-terminal-jarvis` Formula
+7. Monitor CD pipeline
+8. Merge `develop` into `main`
+9. Verify `homebrew-terminal-jarvis` repo has the updated Formula
 
 ## Working Rules
 


### PR DESCRIPTION
## Summary

- Uploads the Anchore/Grype SARIF output from the `security-general` job through `github/codeql-action/upload-sarif@v4`.
- Validates the SARIF output path reported by the Anchore action before upload so missing or empty scan output fails CI.
- Keeps the category stable as `security-general` so GitHub Code Scanning can ingest a fresh analysis for the Rollup GHSA alert.

## Validation

- `npm install --package-lock-only` in `e2e`
- `npm audit --audit-level=high` in `e2e`
- `npm install --package-lock-only` in `npm/terminal-jarvis`
- `npm audit --audit-level=high` in `npm/terminal-jarvis`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= ./scripts/verify/verify-change.sh --quick`

## Release posture

This is staged for the `0.0.82` train. Do not push `v0.0.82` or publish final artifacts until NPM publishing access is restored.
