### PR TITLE
fix(docs): address PR 77 review feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,6 @@ jobs:
       # - RUSTSEC-2026-0037 / RUSTSEC-2026-0049 / RUSTSEC-2026-0098 / RUSTSEC-2026-0099 / RUSTSEC-2026-0104:
       #   rustls-webpki and quinn-proto issues in libsql/reqwest transitive deps; fixed where possible via cargo update,
       #   remaining rustls-webpki 0.102.8 issues blocked on libsql upgrading from rustls 0.22
-      # - RUSTSEC-2026-0097: rand unsoundness fixed by updating to rand 0.8.6 / 0.9.4
       run: cargo audit --deny warnings --ignore RUSTSEC-2025-0134 --ignore RUSTSEC-2025-0141 --ignore RUSTSEC-2024-0375 --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2026-0049 --ignore RUSTSEC-2026-0037 --ignore RUSTSEC-2026-0098 --ignore RUSTSEC-2026-0099 --ignore RUSTSEC-2026-0104
 
     - name: Run cargo-deny checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - **Headless Update-All**: `update all` now only attempts to update installed tools, preventing errors in headless/CI environments
 - **Tool Catalog Drift**: Corrected package metadata for `@just-every/code` (bin `coder`), `@nanocollective/nanocoder`, and `@earendil-works/pi-coding-agent` in root and npm-copied configs
-- **Documentation Counts**: Fixed README tool counts (22 -> 23), cli_logic module count (22 -> 19), and docs link tool count (11 -> 23)
+- **Documentation Counts**: Fixed README tool counts to 25 supported tools, cli_logic module count (22 -> 19), and docs link tool count to 25
 
 ### Security
 - **SECURITY.md Restored**: Comprehensive security documentation covering supply chain practices, credential storage, and reporting procedures

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Unified command center for AI coding tools**
 
-Manage Claude, Gemini, Qwen, and 20 more AI assistants from one terminal interface.
+Manage Claude, Gemini, Qwen, and 22 more AI assistants from one terminal interface.
 
 [![NPM Version](https://img.shields.io/npm/v/terminal-jarvis.svg?logo=npm&style=flat-square)](https://www.npmjs.com/package/terminal-jarvis)
 [![Crates.io](https://img.shields.io/crates/v/terminal-jarvis.svg?logo=rust&style=flat-square)](https://crates.io/crates/terminal-jarvis)

--- a/adk/internal/ui/theme.go
+++ b/adk/internal/ui/theme.go
@@ -13,5 +13,5 @@ const (
 	Red    = "\x1b[38;2;255;100;100m"
 	Reset  = "\x1b[0m"
 
-	Version = "v0.0.78"
+	Version = "v0.0.81"
 )

--- a/npm/terminal-jarvis/README.md
+++ b/npm/terminal-jarvis/README.md
@@ -4,7 +4,7 @@
 
 **Unified command center for AI coding tools**
 
-Manage Claude, Gemini, Qwen, and 19 more AI assistants from one terminal interface.
+Manage Claude, Gemini, Qwen, and 22 more AI assistants from one terminal interface.
 
 [![NPM Version](https://img.shields.io/npm/v/terminal-jarvis.svg?logo=npm&style=flat-square)](https://www.npmjs.com/package/terminal-jarvis)
 [![Crates.io](https://img.shields.io/crates/v/terminal-jarvis.svg?logo=rust&style=flat-square)](https://crates.io/crates/terminal-jarvis)
@@ -54,7 +54,7 @@ brew tap ba-calderonmorales/terminal-jarvis && brew install terminal-jarvis  # H
 | Feature | Description |
 |:--------|:------------|
 | **Interactive Interface** | Beautiful terminal UI with ASCII art, themed menus, and keyboard navigation for a polished command-line experience. |
-| **22 AI Tools Supported** | Claude, Gemini, Qwen, OpenCode, Codex, Aider, Goose, Amp, Crush, LLXPRT, and many more - all manageable from a single interface. |
+| **25 AI Tools Supported** | Claude, Gemini, Qwen, OpenCode, Codex, Aider, Goose, Amp, Crush, LLXPRT, and many more - all manageable from a single interface. |
 | **Integrated Installation** | Install, update, or uninstall any supported AI tool directly from the menu without leaving the terminal. |
 | **Session Continuity** | Preserves your terminal session state during browser-based authentication flows. Currently in development with expanding coverage. |
 
@@ -69,7 +69,7 @@ Full guides at **[Terminal Jarvis Docs](https://ba-calderonmorales.github.io/my-
 | Guide | Description |
 |:------|:------------|
 | [Installation](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/quick_start/installation/) | Step-by-step platform setup for NPM, Cargo, and Homebrew with troubleshooting tips for common issues. |
-| [AI Tools](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/quick_start/ai-tools/) | Detailed overview of all 11 supported AI coding assistants including authentication requirements and capabilities. |
+| [AI Tools](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/quick_start/ai-tools/) | Detailed overview of all 25 supported AI coding assistants including authentication requirements and capabilities. |
 | [Configuration](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/quick_start/configuration/) | Customize themes, keybindings, default tools, and environment variables to match your workflow. |
 | [Architecture](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/details/architecture/) | Technical deep-dive into the Rust codebase, module organization, and design decisions. |
 
@@ -83,7 +83,7 @@ terminal-jarvis/
 ├── src/                           # Rust application
 │   ├── main.rs                    # Entry point
 │   ├── cli.rs                     # CLI definitions
-│   ├── cli_logic/                 # Business logic (22 modules)
+│   ├── cli_logic/                 # Business logic (19 modules)
 │   ├── auth_manager/              # Authentication (8 modules)
 │   ├── config/                    # Configuration (6 modules)
 │   ├── services/                  # External integrations (6 modules)

--- a/scripts/tj-fast.sh
+++ b/scripts/tj-fast.sh
@@ -1,4 +1,4 @@
-#!/data/data/com.termux/files/usr/bin/env bash
+#!/usr/bin/env bash
 #
 # tj-fast: Run Terminal Jarvis with local Ollama LLM (Gemma 2B for speed)
 #

--- a/scripts/tj-local.sh
+++ b/scripts/tj-local.sh
@@ -1,4 +1,4 @@
-#!/data/data/com.termux/files/usr/bin/env bash
+#!/usr/bin/env bash
 #
 # tj-local: Run Terminal Jarvis with local Ollama LLM (Gemma 4B for quality)
 #


### PR DESCRIPTION
## Summary

Addresses the remaining Copilot review feedback from PR #77 for issue #80.

- Aligns root and NPM README supported-tool counts to 25.
- Updates the current changelog entry so its documentation-count note matches the catalog reality.
- Updates the ADK UI version text to `v0.0.81`.
- Changes the local helper script shebangs to use `/usr/bin/env bash`.
- Removes the stale `RUSTSEC-2026-0097` cargo-audit comment mismatch from CI.

## Validation

Completed locally on `fix/pr77-review-feedback` before opening this PR:

```bash
cargo fmt --all
CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked tool_catalog_validation_tests
CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked --test tool_catalog_validation_tests
CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked credential_encryption
CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= ./scripts/verify/verify-change.sh --quick
```

The exact handoff filter `cargo test --locked tool_catalog_validation_tests` passed but matched zero individual tests, so the integration test target was also run directly and passed all five tests.

## Release posture

This is staged for the `0.0.82` train. No release tag or publish operation is included here while NPM publishing access remains blocked.