### PR TITLE
feat(config): add interactive config path command

### DIFF
--- a/src/cli_logic/cli_logic_autocomplete.rs
+++ b/src/cli_logic/cli_logic_autocomplete.rs
@@ -37,6 +37,11 @@ pub static COMMANDS: &[CommandDef] = &[
         aliases: &[],
     },
     CommandDef {
+        command: "/config",
+        description: "Configuration Path",
+        aliases: &[],
+    },
+    CommandDef {
         command: "/db",
         description: "Database Management",
         aliases: &[],
@@ -310,6 +315,7 @@ mod tests {
         assert_eq!(ac.resolve_command("/quit"), Some("/exit"));
         assert_eq!(ac.resolve_command("/tools"), Some("/tools"));
         assert_eq!(ac.resolve_command("/help"), Some("/help"));
+        assert_eq!(ac.resolve_command("/config"), Some("/config"));
     }
 
     #[test]
@@ -338,6 +344,7 @@ mod tests {
         let ac = CommandAutocomplete::new();
 
         assert!(ac.is_valid_command("/tools"));
+        assert!(ac.is_valid_command("/config"));
         assert!(ac.is_valid_command("/quit")); // Only remaining alias
         assert!(!ac.is_valid_command("/t")); // No longer an alias
         assert!(!ac.is_valid_command("/invalid"));
@@ -350,6 +357,14 @@ mod tests {
         // "/" should match all commands
         let suggestions = ac.suggest("/");
         assert!(suggestions.len() > 5);
+    }
+
+    #[test]
+    fn test_config_command_suggestions() {
+        let mut ac = CommandAutocomplete::new();
+
+        let suggestions = ac.suggest("/co");
+        assert!(suggestions.iter().any(|s| s.command == "/config"));
     }
 
     #[test]

--- a/src/cli_logic/cli_logic_config_management.rs
+++ b/src/cli_logic/cli_logic_config_management.rs
@@ -3,6 +3,7 @@ use crate::config::{Config, ConfigManager};
 use crate::progress_utils::ProgressUtils;
 use crate::services::PackageService;
 use anyhow::{anyhow, Result};
+use std::path::{Path, PathBuf};
 
 /// Handle resetting configuration to defaults
 pub async fn handle_config_reset() -> Result<()> {
@@ -55,23 +56,121 @@ pub async fn handle_config_show() -> Result<()> {
 
 /// Handle displaying configuration file path
 pub async fn handle_config_path() -> Result<()> {
-    let config_path = match dirs::config_dir() {
-        Some(dir) => dir.join("terminal-jarvis").join("config.toml"),
-        None => {
-            ProgressUtils::error_message("Could not determine config directory");
-            return Err(anyhow!("Could not determine config directory"));
-        }
-    };
+    print_config_path_status();
+    Ok(())
+}
 
-    println!("Configuration file path: {}", config_path.display());
+/// Handle the interactive /config slash command.
+pub fn handle_config_command(args: &str) -> Result<()> {
+    let args = args.trim();
 
-    if config_path.exists() {
-        ProgressUtils::success_message("Configuration file exists");
-    } else {
-        ProgressUtils::info_message("Configuration file does not exist (using defaults)");
+    if args.is_empty() {
+        print_config_path_status();
+        return Ok(());
     }
 
+    if args == "--reset" {
+        crate::cli_logic::cli_logic_first_run::clear_custom_config_path()?;
+        ProgressUtils::success_message("Configuration path override cleared");
+        print_config_path_status();
+        return Ok(());
+    }
+
+    let path = PathBuf::from(args);
+    let canonical = validate_custom_config_path(&path)?;
+    crate::cli_logic::cli_logic_first_run::save_custom_config_path(&canonical)?;
+    ProgressUtils::success_message(&format!(
+        "Configuration path set to {}",
+        canonical.display()
+    ));
+    ProgressUtils::info_message("Future config loads will use this path");
+
     Ok(())
+}
+
+/// Handle the settings submenu for configuration path management.
+pub async fn handle_config_path_menu() -> Result<()> {
+    use crate::cli_logic::themed_components::{themed_select_with, themed_text};
+    use crate::theme::theme_global_config;
+
+    loop {
+        let theme = theme_global_config::current_theme();
+        print!("\x1b[2J\x1b[H");
+        println!("{}\n", theme.accent("Configuration Path"));
+        print_config_path_status();
+        println!();
+
+        let options = vec![
+            "Set Custom Path".to_string(),
+            "Reset to Default".to_string(),
+            "Back to Settings".to_string(),
+        ];
+
+        let selection = match themed_select_with(&theme, "Choose an option:", options).prompt() {
+            Ok(selection) => selection,
+            Err(_) => return Ok(()),
+        };
+
+        match selection.as_str() {
+            "Set Custom Path" => {
+                let input = match themed_text("Config file path:").prompt() {
+                    Ok(input) => input,
+                    Err(_) => continue,
+                };
+                if let Err(e) = handle_config_command(&input) {
+                    ProgressUtils::error_message(&e.to_string());
+                }
+                println!("\n{}", theme.accent("Press Enter to continue..."));
+                let _ = std::io::stdin().read_line(&mut String::new());
+            }
+            "Reset to Default" => {
+                handle_config_command("--reset")?;
+                println!("\n{}", theme.accent("Press Enter to continue..."));
+                let _ = std::io::stdin().read_line(&mut String::new());
+            }
+            _ => return Ok(()),
+        }
+    }
+}
+
+fn print_config_path_status() {
+    let default_path =
+        crate::config::default_config_path().unwrap_or_else(|| PathBuf::from("config.toml"));
+    let (active_path, is_custom) = crate::config::active_config_path();
+    let mode = if is_custom { "custom" } else { "default" };
+    let exists = if active_path.exists() { "yes" } else { "no" };
+
+    println!("Configuration path: {}", active_path.display());
+    println!("Path type: {mode}");
+    println!("File exists: {exists}");
+    println!("Default path: {}", default_path.display());
+}
+
+fn validate_custom_config_path(path: &Path) -> Result<PathBuf> {
+    if !path.exists() {
+        return Err(anyhow!(
+            "Configuration file does not exist: {}",
+            path.display()
+        ));
+    }
+
+    if !path.is_file() {
+        return Err(anyhow!(
+            "Configuration path must be a file: {}",
+            path.display()
+        ));
+    }
+
+    let canonical = path.canonicalize()?;
+    let content = std::fs::read_to_string(&canonical)?;
+    toml::from_str::<Config>(&content).map_err(|e| {
+        anyhow!(
+            "Configuration file is not valid Terminal Jarvis TOML: {}",
+            e
+        )
+    })?;
+
+    Ok(canonical)
 }
 
 /// Handle clearing version cache
@@ -136,5 +235,75 @@ fn display_cache_info(cache: &crate::config::VersionCache) {
     } else {
         let remaining = cache.remaining_seconds();
         println!(" Status: Valid ({remaining} seconds remaining)");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn write_valid_config(path: &Path) {
+        let config = Config::default();
+        std::fs::write(path, toml::to_string_pretty(&config).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn test_validate_custom_config_path_rejects_missing_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing_path = temp_dir.path().join("missing.toml");
+
+        let result = validate_custom_config_path(&missing_path);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_custom_config_path_rejects_invalid_toml() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let invalid_path = temp_dir.path().join("invalid.toml");
+        std::fs::write(&invalid_path, "not = [valid").unwrap();
+
+        let result = validate_custom_config_path(&invalid_path);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_config_command_persists_valid_path_and_rejects_invalid_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let temp_home = tempfile::tempdir().unwrap();
+        let old_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", temp_home.path());
+
+        crate::cli_logic::cli_logic_first_run::clear_custom_config_path().unwrap();
+
+        let valid_path = temp_home.path().join("valid.toml");
+        write_valid_config(&valid_path);
+        handle_config_command(valid_path.to_str().unwrap()).unwrap();
+
+        let stored = crate::cli_logic::cli_logic_first_run::get_custom_config_path().unwrap();
+        assert_eq!(stored, valid_path.canonicalize().unwrap());
+
+        let missing_path = temp_home.path().join("missing.toml");
+        assert!(handle_config_command(missing_path.to_str().unwrap()).is_err());
+        assert_eq!(
+            crate::cli_logic::cli_logic_first_run::get_custom_config_path(),
+            Some(stored)
+        );
+
+        handle_config_command("--reset").unwrap();
+        assert_eq!(
+            crate::cli_logic::cli_logic_first_run::get_custom_config_path(),
+            None
+        );
+
+        if let Some(home) = old_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
     }
 }

--- a/src/cli_logic/cli_logic_entry_point.rs
+++ b/src/cli_logic/cli_logic_entry_point.rs
@@ -358,6 +358,7 @@ pub async fn handle_manage_tools_menu() -> Result<()> {
             "List All Tools".to_string(),
             "Tool Information".to_string(),
             "Authentication".to_string(),
+            "Configuration Path".to_string(),
             "Switch Theme".to_string(),
             "Back to Main Menu".to_string(),
         ];
@@ -387,6 +388,9 @@ pub async fn handle_manage_tools_menu() -> Result<()> {
             }
             s if s.contains("Authentication") => {
                 crate::cli_logic::handle_authentication_menu().await?;
+            }
+            s if s.contains("Configuration Path") => {
+                handle_config_path_menu().await?;
             }
             s if s.contains("Switch Theme") => {
                 handle_theme_switch_menu().await?;

--- a/src/cli_logic/cli_logic_first_run.rs
+++ b/src/cli_logic/cli_logic_first_run.rs
@@ -7,7 +7,7 @@ use crate::tools::ToolManager;
 use anyhow::Result;
 use std::fs;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Get the Terminal Jarvis config directory path
 pub fn get_config_dir() -> Option<PathBuf> {
@@ -213,21 +213,48 @@ fn get_preferences_path() -> Option<PathBuf> {
     get_config_dir().map(|d| d.join("preferences.json"))
 }
 
-/// Save the last-used tool (hybrid: database + file fallback)
-pub fn save_last_used_tool(tool: &str) -> Result<()> {
-    // Try database first (async context required)
-    // Fall back to file-based for sync context
+fn read_file_preferences() -> serde_json::Map<String, serde_json::Value> {
+    let Some(prefs_path) = get_preferences_path() else {
+        return serde_json::Map::new();
+    };
+
+    let Ok(content) = fs::read_to_string(&prefs_path) else {
+        return serde_json::Map::new();
+    };
+
+    serde_json::from_str::<serde_json::Value>(&content)
+        .ok()
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default()
+}
+
+fn write_file_preferences(prefs: &serde_json::Map<String, serde_json::Value>) -> Result<()> {
     if let Some(prefs_path) = get_preferences_path() {
         if let Some(parent) = prefs_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let prefs = serde_json::json!({
-            "last_used_tool": tool,
-            "updated_at": chrono::Utc::now().to_rfc3339()
-        });
-        fs::write(&prefs_path, serde_json::to_string_pretty(&prefs)?)?;
+        fs::write(
+            &prefs_path,
+            serde_json::to_string_pretty(&serde_json::Value::Object(prefs.clone()))?,
+        )?;
     }
     Ok(())
+}
+
+/// Save the last-used tool (hybrid: database + file fallback)
+pub fn save_last_used_tool(tool: &str) -> Result<()> {
+    // Try database first (async context required)
+    // Fall back to file-based for sync context
+    let mut prefs = read_file_preferences();
+    prefs.insert(
+        "last_used_tool".to_string(),
+        serde_json::Value::String(tool.to_string()),
+    );
+    prefs.insert(
+        "updated_at".to_string(),
+        serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+    );
+    write_file_preferences(&prefs)
 }
 
 /// Save the last-used tool to database (async version)
@@ -244,13 +271,44 @@ pub async fn save_last_used_tool_async(tool: &str) -> Result<()> {
 /// Get the last-used tool (hybrid: database + file fallback)
 pub fn get_last_used_tool() -> Option<String> {
     // Try file-based first (sync context)
-    let prefs_path = get_preferences_path()?;
-    let content = fs::read_to_string(&prefs_path).ok()?;
-    let prefs: serde_json::Value = serde_json::from_str(&content).ok()?;
-    prefs
+    read_file_preferences()
         .get("last_used_tool")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
+}
+
+/// Save the custom configuration file path in file-based preferences.
+pub fn save_custom_config_path(path: &Path) -> Result<()> {
+    let mut prefs = read_file_preferences();
+    prefs.insert(
+        "config_path".to_string(),
+        serde_json::Value::String(path.to_string_lossy().to_string()),
+    );
+    prefs.insert(
+        "updated_at".to_string(),
+        serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+    );
+    write_file_preferences(&prefs)
+}
+
+/// Get the custom configuration file path from file-based preferences.
+pub fn get_custom_config_path() -> Option<PathBuf> {
+    read_file_preferences()
+        .get("config_path")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .map(PathBuf::from)
+}
+
+/// Clear the custom configuration file path from file-based preferences.
+pub fn clear_custom_config_path() -> Result<()> {
+    let mut prefs = read_file_preferences();
+    prefs.remove("config_path");
+    prefs.insert(
+        "updated_at".to_string(),
+        serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+    );
+    write_file_preferences(&prefs)
 }
 
 /// Get the last-used tool from database (async version)
@@ -263,6 +321,10 @@ pub async fn get_last_used_tool_async() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Config;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_detect_tools_returns_valid_result() {
@@ -283,6 +345,43 @@ mod tests {
         // Should return Some path when home dir exists
         if let Some(config_dir) = get_config_dir() {
             assert!(config_dir.to_string_lossy().contains(".terminal-jarvis"));
+        }
+    }
+
+    #[test]
+    fn test_custom_config_path_preferences_persist_and_reset() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let temp_home = tempfile::tempdir().unwrap();
+        let old_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", temp_home.path());
+
+        let config_path = temp_home.path().join("custom-config.toml");
+        let mut custom_config = Config::default();
+        custom_config.api.base_url = "https://custom-config.example".to_string();
+        fs::write(
+            &config_path,
+            toml::to_string_pretty(&custom_config).unwrap(),
+        )
+        .unwrap();
+
+        save_last_used_tool("codex").unwrap();
+        save_custom_config_path(&config_path).unwrap();
+
+        assert_eq!(get_custom_config_path(), Some(config_path));
+        assert_eq!(get_last_used_tool(), Some("codex".to_string()));
+        assert_eq!(
+            Config::load().unwrap().api.base_url,
+            "https://custom-config.example"
+        );
+
+        clear_custom_config_path().unwrap();
+        assert_eq!(get_custom_config_path(), None);
+        assert_eq!(get_last_used_tool(), Some("codex".to_string()));
+
+        if let Some(home) = old_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
         }
     }
 }

--- a/src/cli_logic/cli_logic_interactive.rs
+++ b/src/cli_logic/cli_logic_interactive.rs
@@ -138,6 +138,10 @@ async fn execute_command(
             handle_manage_tools_menu().await?;
             refresh_screen(theme, npm_available).await?;
         }
+        s if s == "/config" || s.starts_with("/config ") => {
+            let args = s.strip_prefix("/config").unwrap_or("").trim();
+            crate::cli_logic::handle_config_command(args)?;
+        }
         "/db" => {
             print!("\x1b[2J\x1b[H");
             crate::cli_logic::handle_db_menu().await?;
@@ -223,6 +227,7 @@ fn display_available_commands(theme: &crate::theme::Theme) {
             println!("  /auth       Authentication");
             println!("  /links      Important Links");
             println!("  /settings   Settings");
+            println!("  /config     Configuration Path");
             println!("  /db         Database Management");
             println!("  /theme      Change UI Theme");
             println!("  /dashboard  Tool Health Status");
@@ -253,6 +258,11 @@ fn display_available_commands(theme: &crate::theme::Theme) {
                 "  {} {}",
                 theme.accent("/settings"),
                 theme.secondary("Install/update/configure")
+            );
+            println!(
+                "  {} {}",
+                theme.accent("/config"),
+                theme.secondary("Manage configuration path")
             );
             println!(
                 "  {} {}",
@@ -289,6 +299,7 @@ fn display_available_commands(theme: &crate::theme::Theme) {
             println!("  {} - Authentication", theme.secondary("/auth"));
             println!("  {} - Important Links", theme.secondary("/links"));
             println!("  {} - Settings", theme.secondary("/settings"));
+            println!("  {} - Configuration Path", theme.secondary("/config"));
             println!("  {} - Database Management", theme.secondary("/db"));
             println!("  {} - Change UI Theme", theme.secondary("/theme"));
             println!("  {} - Tool Health Status", theme.secondary("/dashboard"));

--- a/src/config/config_file_operations.rs
+++ b/src/config/config_file_operations.rs
@@ -12,13 +12,37 @@
 
 use crate::config::config_structures::{Config, ToolConfig};
 use anyhow::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// Default per-user configuration path.
+pub fn default_config_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|p| p.join("terminal-jarvis").join("config.toml"))
+}
+
+/// Custom configuration path persisted in user preferences, if configured.
+pub fn custom_config_path() -> Option<PathBuf> {
+    crate::cli_logic::cli_logic_first_run::get_custom_config_path()
+}
+
+/// Active configuration path and whether it comes from a custom preference.
+pub fn active_config_path() -> (PathBuf, bool) {
+    if let Some(path) = custom_config_path() {
+        return (path, true);
+    }
+
+    (
+        default_config_path().unwrap_or_else(|| PathBuf::from("config.toml")),
+        false,
+    )
+}
 
 impl Config {
     /// Load configuration from file or create default
     pub fn load() -> Result<Self> {
+        let custom_path = custom_config_path();
         let config_paths = vec![
-            dirs::config_dir().map(|p| p.join("terminal-jarvis").join("config.toml")),
+            custom_path.clone(),
+            default_config_path(),
             Some(PathBuf::from("./terminal-jarvis.toml")),
             Some(PathBuf::from("./terminal-jarvis.toml.example")),
             // Add NPM package config path - look relative to binary location
@@ -34,50 +58,47 @@ impl Config {
         // Try to load user configuration and merge it
         for path in config_paths.into_iter().flatten() {
             if path.exists() {
-                match std::fs::read_to_string(&path) {
-                    Ok(content) => {
-                        // Try to parse as partial TOML first, then fallback to full Config
-                        match toml::from_str::<Config>(&content) {
-                            Ok(user_config) => {
-                                // Merge user config with defaults (user settings override defaults)
-                                for (tool_name, tool_config) in user_config.tools {
-                                    config.tools.insert(tool_name, tool_config);
-                                }
-
-                                // Update other settings if they exist in user config
-                                config.templates = user_config.templates;
-                                config.api = user_config.api;
-
-                                // Ensure all defaults are still present
-                                config.ensure_default_tools();
-                                return Ok(config);
-                            }
-                            Err(e) => {
-                                eprintln!(
-                                    "Warning: Failed to parse config file {}: {}",
-                                    path.display(),
-                                    e
-                                );
-                                eprintln!("Using default configuration");
-                                continue;
-                            }
-                        }
-                    }
+                match Self::load_from_path(&path, &mut config) {
+                    Ok(()) => return Ok(config),
                     Err(e) => {
                         eprintln!(
-                            "Warning: Failed to read config file {}: {}",
+                            "Warning: Failed to load config file {}: {}",
                             path.display(),
                             e
                         );
-                        continue;
+                        eprintln!("Using default configuration");
+                        if custom_path.as_ref() == Some(&path) {
+                            return Err(e);
+                        }
                     }
-                }
+                };
+            } else if custom_path.as_ref() == Some(&path) {
+                return Err(anyhow::anyhow!(
+                    "Custom configuration file does not exist: {}",
+                    path.display()
+                ));
             }
         }
 
         // Return default config if no file found (ensure defaults are present)
         config.ensure_default_tools();
         Ok(config)
+    }
+
+    /// Validate and merge a configuration file into the provided config.
+    pub fn load_from_path(path: &Path, config: &mut Config) -> Result<()> {
+        let content = std::fs::read_to_string(path)?;
+        let user_config = toml::from_str::<Config>(&content)?;
+
+        for (tool_name, tool_config) in user_config.tools {
+            config.tools.insert(tool_name, tool_config);
+        }
+
+        config.templates = user_config.templates;
+        config.api = user_config.api;
+        config.ensure_default_tools();
+
+        Ok(())
     }
 
     /// Save configuration to the user config directory

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,5 +13,6 @@ mod config_version_cache;
 // Re-export main interfaces
 #[allow(unused_imports)]
 pub use config_entry_point::{ApiConfig, Config, TemplateConfig, ToolConfig};
+pub use config_file_operations::{active_config_path, default_config_path};
 pub use config_manager::ConfigManager;
 pub use config_version_cache::VersionCache;


### PR DESCRIPTION
## Summary

- Adds `/config` as a root interactive slash command for viewing, setting, and resetting a custom configuration file path.
- Persists the custom path in the existing preferences store and preserves unrelated preference keys.
- Makes `Config::load()` prefer the stored custom path while keeping default config resolution unchanged when no override is set.
- Adds `/config` help/autocomplete support and a `Configuration Path` settings-menu entry.

Refs #83. Pending human-driver validation before closing.

## Validation

Final validation was rerun after rebasing the branch onto `origin/develop` so the PR diff stays limited to #83.

```bash
CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked cli_logic_autocomplete
# passed: 9 tests

CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked cli_logic_config_management
# passed: 3 tests

CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked cli_logic_first_run
# passed: 4 tests

CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= ./scripts/verify/verify-change.sh --quick
# passed: all checks, duration 309s
```