### PR TITLE
docs(triage): update quality score status

### DIFF
--- a/.github/issue-updates/64-quality-score-status.md
+++ b/.github/issue-updates/64-quality-score-status.md
@@ -1,0 +1,75 @@
+# Issue #64 Quality Score Status
+
+Prepared: 2026-05-12
+
+## Recommended Issue Action
+
+Narrow #64 to current external Socket.dev or npm quality-score findings only.
+The local artifacts named in the issue are present or covered by existing
+checks, and the one rustdoc warning found during this audit was fixed.
+
+Do not keep #64 open for broad documentation rewrites, release work, package
+publishing, or architecture changes. Those belong to separate issues.
+
+## Evidence Checked
+
+- GitHub issue #64 is still open and has no comments.
+- Root README has npm, crates.io, Homebrew, license, docs, and coverage badges.
+- NPM README has npm, crates.io, Homebrew, license, docs, and coverage badges.
+- `CHANGELOG.md` records TypeScript definitions, quality badges, and CI coverage
+  work in `0.0.80`.
+- `npm/terminal-jarvis/index.d.ts` exists and defines the NPM wrapper API.
+- `npm/terminal-jarvis/package.json` declares `"types": "index.d.ts"` and
+  includes `index.d.ts` in the package `files` list.
+- The published npm package metadata for `terminal-jarvis@0.0.81` declares
+  `types: index.d.ts`, `license: MIT`, repository, bugs URL, homepage,
+  keywords, bin, and Node engine metadata.
+- Current npm dist-tags are `latest: 0.0.81`, `stable: 0.0.81`, and
+  `beta: 0.0.81`; this confirms the prior `0.0.80` dist-tag evidence is stale.
+- `.github/workflows/ci.yml` runs Rust formatting, clippy, test build, Rust
+  tests, and a cargo-tarpaulin coverage report step.
+- E2E tests exist for install, direct invocation, help, list, version, error
+  handling, auth menu, config menu, main menu, and templates menu paths.
+- `.github/hooks/pre-commit` exists and runs docs validation when
+  `scripts/verify/verify-docs.sh` is available.
+
+## Validation Run
+
+```bash
+npm view terminal-jarvis --json
+npm view terminal-jarvis@0.0.81 types readmeFilename license homepage repository.url bugs.url keywords bin engines version dist.fileCount dist.unpackedSize --json
+CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo doc --locked --no-deps
+cd npm/terminal-jarvis && npm run typecheck
+```
+
+After fixing the rustdoc literal-bracket warning:
+
+```bash
+CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo doc --locked --no-deps
+```
+
+## External Status
+
+Socket.dev live package status could not be verified from this environment.
+Requests to `https://socket.dev/npm/package/terminal-jarvis` returned HTTP 403,
+and `https://socket.dev/api/npm/package/terminal-jarvis` returned a Cloudflare
+challenge page. The unauthenticated API probe at
+`https://api.socket.dev/v0/npm/package/terminal-jarvis` returned
+`API route not found`.
+
+Because the live Socket.dev score could not be read here, #64 should be updated
+with the local evidence above and narrowed to one of these remaining actions:
+
+1. Verify the Socket.dev score in a browser or authenticated Socket.dev context.
+2. If Socket.dev still reports a concrete quality finding, track only that
+   finding in #64.
+3. If no concrete finding remains, close #64 as satisfied by the existing
+   TypeScript definitions, badges, documentation hosting, tests, CI quality
+   gates, and npm package metadata.
+
+## Out Of Scope For #64
+
+- Publishing or release-train changes.
+- README count drift already tracked by #54 and #80.
+- Maintenance score work tracked by #63.
+- Architecture or release-process changes.

--- a/src/tools/tools_display.rs
+++ b/src/tools/tools_display.rs
@@ -193,7 +193,7 @@ impl ToolDisplayFormatter {
 
     /// Format a tool name with requirement hint for menu display
     ///
-    /// Returns a formatted string like "claude [npm]" or "aider [uv]"
+    /// Returns a formatted string like "claude \[npm\]" or "aider \[uv\]"
     /// with visual indicators if the required package manager is missing.
     pub fn format_menu_item(tool_name: &str, tool_info: &ToolInfo) -> String {
         let label = tool_info.package_manager.label();


### PR DESCRIPTION
## Summary
- add issue-ready evidence for #64 quality-score status
- record current npm 0.0.81 package and dist-tag state
- fix the rustdoc literal bracket example found during the quality audit

## Validation
- npm view terminal-jarvis@0.0.81 version
- npm dist-tag ls terminal-jarvis
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked tools_display
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= ./scripts/verify/verify-change.sh --quick

Refs #64