### PR TITLE
fix(security): address PR #77 review feedback

### DIFF
--- a/src/security/credential_encryption.rs
+++ b/src/security/credential_encryption.rs
@@ -552,7 +552,9 @@ mod tests {
             keychain_preferred: false,
             ..EncryptionConfig::default()
         };
-        let mut encryption = CredentialEncryption::with_master_key(config, vec![7; 32]);
+        let mut key = vec![0u8; 32];
+        rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut key);
+        let mut encryption = CredentialEncryption::with_master_key(config, key);
         let encrypted_path = encryption.encrypted_creds_path().unwrap();
         std::fs::write(&encrypted_path, b"not-json").unwrap();
 

--- a/src/security/credential_encryption.rs
+++ b/src/security/credential_encryption.rs
@@ -254,15 +254,12 @@ impl CredentialEncryption {
             .map_err(|e| anyhow!("Encryption failed: {:?}", e))?;
 
         // Preserve existing salt so future decryption can re-derive the same key.
-        // If no store exists yet, generate a fresh random salt.
+        // If an existing store cannot be parsed, fail fast rather than pairing
+        // a cached key with a new salt that cannot be re-derived later.
         let salt = if let Ok(encoded) = fs::read(&path) {
-            if let Ok(existing) = serde_json::from_slice::<EncryptedCredentialStore>(&encoded) {
-                existing.salt
-            } else {
-                let mut salt = [0u8; 32];
-                rand::thread_rng().fill_bytes(&mut salt);
-                salt.to_vec()
-            }
+            let existing = serde_json::from_slice::<EncryptedCredentialStore>(&encoded)
+                .context("Failed to parse existing encrypted credential store")?;
+            existing.salt
         } else {
             let mut salt = [0u8; 32];
             rand::thread_rng().fill_bytes(&mut salt);
@@ -537,5 +534,46 @@ mod tests {
             "Platform Keychain"
         );
         assert_eq!(format!("{}", EncryptionMethod::Aes256Gcm), "AES-256-GCM");
+    }
+
+    #[cfg(feature = "credential-encryption")]
+    #[test]
+    fn test_cached_key_fails_fast_when_existing_store_is_corrupt() {
+        let _guard = crate::cli_logic::cli_logic_first_run::TEST_ENV_LOCK
+            .lock()
+            .unwrap();
+        let temp_config = tempfile::tempdir().unwrap();
+        let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
+        let old_appdata = std::env::var_os("APPDATA");
+        std::env::set_var("XDG_CONFIG_HOME", temp_config.path());
+        std::env::set_var("APPDATA", temp_config.path());
+
+        let config = EncryptionConfig {
+            keychain_preferred: false,
+            ..EncryptionConfig::default()
+        };
+        let mut encryption = CredentialEncryption::with_master_key(config, vec![7; 32]);
+        let encrypted_path = encryption.encrypted_creds_path().unwrap();
+        std::fs::write(&encrypted_path, b"not-json").unwrap();
+
+        let mut tools = HashMap::new();
+        tools.insert("gemini".to_string(), HashMap::new());
+
+        let err = encryption.store_credentials(&tools).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Failed to parse existing encrypted credential store"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(std::fs::read(&encrypted_path).unwrap(), b"not-json");
+
+        match old_xdg_config_home {
+            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+        match old_appdata {
+            Some(value) => std::env::set_var("APPDATA", value),
+            None => std::env::remove_var("APPDATA"),
+        }
     }
 }

--- a/src/security/credential_encryption.rs
+++ b/src/security/credential_encryption.rs
@@ -552,8 +552,7 @@ mod tests {
             keychain_preferred: false,
             ..EncryptionConfig::default()
         };
-        let mut key = vec![0u8; 32];
-        rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut key);
+        let key: Vec<u8> = (0..32).map(|_| rand::random::<u8>()).collect();
         let mut encryption = CredentialEncryption::with_master_key(config, key);
         let encrypted_path = encryption.encrypted_creds_path().unwrap();
         std::fs::write(&encrypted_path, b"not-json").unwrap();

--- a/tests/tool_catalog_validation_tests.rs
+++ b/tests/tool_catalog_validation_tests.rs
@@ -83,6 +83,12 @@ fn normalize_npm_package(package: &str) -> &str {
     package.strip_suffix("@latest").unwrap_or(package)
 }
 
+fn contains_interactive_token(part: &str, interactive_tokens: &[&str]) -> bool {
+    part.to_ascii_lowercase()
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .any(|token| interactive_tokens.contains(&token))
+}
+
 #[test]
 fn tool_catalog_configs_parse_and_define_required_commands() {
     let configs = load_tool_configs();
@@ -143,7 +149,7 @@ fn tool_catalog_update_commands_are_non_interactive() {
 
         for part in update_parts {
             assert!(
-                !interactive_tokens.contains(&part),
+                !contains_interactive_token(part, &interactive_tokens),
                 "tool.update for '{tool_name}' appears interactive in {}: token '{part}'",
                 path.display()
             );


### PR DESCRIPTION
## Summary

Addresses the remaining actionable Copilot review feedback tracked by #80 after re-auditing current `develop`.

Already verified as fixed on `develop` before this patch:
- README and CHANGELOG tool-count drift
- ADK UI version constant
- `tj-fast.sh` and `tj-local.sh` shebang portability
- stale cargo-audit comment mentioning an unignored advisory

This PR handles the remaining code/test items:
- Fail fast when an existing encrypted credential store cannot be parsed while reusing a cached master key, avoiding a non-recoverable salt/key mismatch.
- Strengthen update-command catalog validation so interactive words are caught inside compound command strings, not only exact argument matches.

## Validation

- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked cli_logic_autocomplete`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked cli_logic_config_management`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked cli_logic_first_run`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked security::credential_encryption::tests::test_cached_key_fails_fast_when_existing_store_is_corrupt`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked --test tool_catalog_validation_tests tool_catalog_update_commands_are_non_interactive`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked security::credential_encryption`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked --test tool_catalog_validation_tests`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= ./scripts/verify/verify-change.sh`

Refs #80