### PR TITLE
fix(npm): support Android Termux binaries

### DIFF
--- a/npm/terminal-jarvis/scripts/postinstall.js
+++ b/npm/terminal-jarvis/scripts/postinstall.js
@@ -330,7 +330,16 @@ async function main() {
 }
 
 if (require.main === module) {
-    main();
+    void main().catch((err) => {
+        error(`Installation failed: ${err && err.message ? err.message : err}`);
+        warn('Fallback options:');
+        console.log('  1. Install via cargo: cargo install terminal-jarvis');
+        console.log('  2. Install via Homebrew: brew install ba-calderonmorales/terminal-jarvis/terminal-jarvis');
+        console.log('  3. Download manually from: https://github.com/BA-CalderonMorales/terminal-jarvis/releases');
+
+        // Don't fail npm install completely
+        process.exit(0);
+    });
 }
 
 module.exports = {

--- a/npm/terminal-jarvis/scripts/postinstall.js
+++ b/npm/terminal-jarvis/scripts/postinstall.js
@@ -42,9 +42,7 @@ function error(msg) {
 /**
  * Detect platform and return download information
  */
-function getPlatformInfo() {
-    const platform = os.platform();
-    const arch = os.arch();
+function getPlatformInfo(platform = os.platform(), arch = os.arch()) {
 
     // Map to GitHub release file names
     if (platform === 'darwin' && (arch === 'x64' || arch === 'arm64')) {
@@ -55,9 +53,9 @@ function getPlatformInfo() {
         };
     }
 
-    if (platform === 'linux' && (arch === 'x64' || arch === 'arm64')) {
+    if ((platform === 'linux' || platform === 'android') && (arch === 'x64' || arch === 'arm64')) {
         return {
-            name: 'Linux',
+            name: platform === 'android' ? 'Android/Termux' : 'Linux',
             file: 'terminal-jarvis-linux.tar.gz',
             isWindows: false
         };
@@ -193,7 +191,10 @@ function checkPrerequisites() {
         const platform = os.platform();
 
         if (missing.includes('tar')) {
-            if (platform === 'linux') {
+            if (platform === 'android') {
+                warn('Install tar using Termux packages:');
+                console.log('  pkg update && pkg install -y tar');
+            } else if (platform === 'linux') {
                 warn('Install tar using your package manager:');
                 console.log('  Debian/Ubuntu: sudo apt-get update && sudo apt-get install -y tar');
                 console.log('  Fedora/RHEL:   sudo dnf install -y tar');
@@ -215,7 +216,7 @@ function checkPrerequisites() {
 /**
  * Main installation workflow - optimized for speed
  */
-(async () => {
+async function main() {
     const startTime = Date.now();
 
     // Skip binary download in CI environments - binary hasn't been released yet
@@ -326,4 +327,15 @@ function checkPrerequisites() {
         // Don't fail npm install completely
         process.exit(0);
     }
-})();
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = {
+    getPlatformInfo,
+    getAssetUrl,
+    checkPrerequisites,
+    main
+};

--- a/npm/terminal-jarvis/src/index.ts
+++ b/npm/terminal-jarvis/src/index.ts
@@ -4,39 +4,15 @@ import { spawn } from "child_process";
 import { existsSync } from "fs";
 import { arch, platform } from "os";
 import { join } from "path";
+import { getBundledBinaryName } from "./platform";
 
 function getBundledBinaryPath(): string {
-  const currentPlatform = platform();
-  const currentArch = arch();
-
-  // Map Node.js platform/arch to our binary naming convention
-  let binaryName = "terminal-jarvis";
-
-  if (currentPlatform === "linux") {
-    binaryName += "-linux";
-  } else if (currentPlatform === "darwin") {
-    binaryName += "-macos";
-  } else if (currentPlatform === "win32") {
-    binaryName += "-windows.exe";
-  } else {
-    binaryName += "-linux"; // fallback
-  }
-
-  if (currentPlatform !== "win32") {
-    if (currentArch === "x64" || currentArch === "x86_64") {
-      binaryName += "-x64";
-    } else if (currentArch === "arm64") {
-      binaryName += "-arm64";
-    } else {
-      binaryName += "-x64"; // fallback
-    }
-  }
-
-  return join(__dirname, "..", "bin", binaryName);
+  return join(__dirname, "..", "bin", getBundledBinaryName(platform(), arch()));
 }
 
 // Try to find the Rust binary in common locations
 const possibleBinaries = [
+  getBundledBinaryPath(),
   join(__dirname, "..", "bin", "terminal-jarvis"), // Bundled binary (generic)
   join(__dirname, "..", "bin", "terminal-jarvis-linux-x64"), // Bundled binary (platform-specific)
   join(__dirname, "..", "..", "..", "target", "debug", "terminal-jarvis"), // Local debug build

--- a/npm/terminal-jarvis/src/platform.ts
+++ b/npm/terminal-jarvis/src/platform.ts
@@ -1,0 +1,30 @@
+export type SupportedPlatform = NodeJS.Platform | "android";
+
+export function getBundledBinaryName(
+  currentPlatform: SupportedPlatform,
+  currentArch: string,
+): string {
+  let binaryName = "terminal-jarvis";
+
+  if (currentPlatform === "linux" || currentPlatform === "android") {
+    binaryName += "-linux";
+  } else if (currentPlatform === "darwin") {
+    binaryName += "-macos";
+  } else if (currentPlatform === "win32") {
+    binaryName += "-windows.exe";
+  } else {
+    binaryName += "-linux";
+  }
+
+  if (currentPlatform !== "win32") {
+    if (currentArch === "x64" || currentArch === "x86_64") {
+      binaryName += "-x64";
+    } else if (currentArch === "arm64") {
+      binaryName += "-arm64";
+    } else {
+      binaryName += "-x64";
+    }
+  }
+
+  return binaryName;
+}

--- a/npm/terminal-jarvis/tests/platform.test.ts
+++ b/npm/terminal-jarvis/tests/platform.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+import { getBundledBinaryName } from "../src/platform";
+
+const { getPlatformInfo } = require("../scripts/postinstall.js");
+
+describe("platform resolution", () => {
+  test("launcher maps Android arm64 to Linux ARM64 bundled binary", () => {
+    expect(getBundledBinaryName("android", "arm64")).toBe(
+      "terminal-jarvis-linux-arm64",
+    );
+  });
+
+  test("launcher maps Android x64 to Linux x64 bundled binary", () => {
+    expect(getBundledBinaryName("android", "x64")).toBe(
+      "terminal-jarvis-linux-x64",
+    );
+  });
+
+  test("postinstall maps Android arm64 to Linux release archive", () => {
+    expect(getPlatformInfo("android", "arm64")).toEqual({
+      name: "Android/Termux",
+      file: "terminal-jarvis-linux.tar.gz",
+      isWindows: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Treat Node's android platform as Linux for bundled binary resolution.
- Share launcher platform mapping through a small testable helper.
- Update postinstall platform detection and Termux tar guidance.

## Validation

- npm test
- npm run build
- CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= ./scripts/verify/verify-change.sh --quick

Refs #65