### PR TITLE
refactor(cli): model slash commands as enum

### DIFF
--- a/src/cli_logic/cli_logic_autocomplete.rs
+++ b/src/cli_logic/cli_logic_autocomplete.rs
@@ -4,69 +4,8 @@
 // Uses a simple prefix tree (trie-like) structure with caching for
 // fast lookups during interactive input.
 
+use crate::cli_logic::command::SlashCommand;
 use std::collections::HashMap;
-
-/// Command definition with metadata
-#[derive(Debug, Clone)]
-pub struct CommandDef {
-    pub command: &'static str,
-    pub description: &'static str,
-    pub aliases: &'static [&'static str],
-}
-
-/// Static command definitions - full names only, no single-letter aliases
-pub static COMMANDS: &[CommandDef] = &[
-    CommandDef {
-        command: "/tools",
-        description: "AI CLI Tools",
-        aliases: &[],
-    },
-    CommandDef {
-        command: "/auth",
-        description: "Authentication",
-        aliases: &[],
-    },
-    CommandDef {
-        command: "/links",
-        description: "Important Links",
-        aliases: &[],
-    },
-    CommandDef {
-        command: "/settings",
-        description: "Settings",
-        aliases: &[],
-    },
-    CommandDef {
-        command: "/config",
-        description: "Configuration Path",
-        aliases: &[],
-    },
-    CommandDef {
-        command: "/db",
-        description: "Database Management",
-        aliases: &[],
-    },
-    CommandDef {
-        command: "/theme",
-        description: "Change UI Theme",
-        aliases: &[],
-    },
-    CommandDef {
-        command: "/dashboard",
-        description: "Tool Health Dashboard",
-        aliases: &["/status"],
-    },
-    CommandDef {
-        command: "/help",
-        description: "Show help",
-        aliases: &[],
-    },
-    CommandDef {
-        command: "/exit",
-        description: "Exit",
-        aliases: &["/quit"],
-    },
-];
 
 /// Autocomplete suggestion with match info
 #[derive(Debug, Clone)]
@@ -96,10 +35,10 @@ impl CommandAutocomplete {
         let mut all_commands = Vec::new();
 
         // Add all commands and their aliases
-        for cmd in COMMANDS {
-            all_commands.push((cmd.command.to_string(), cmd.description.to_string()));
-            for alias in cmd.aliases {
-                all_commands.push((alias.to_string(), cmd.description.to_string()));
+        for cmd in SlashCommand::all() {
+            all_commands.push((cmd.command().to_string(), cmd.description().to_string()));
+            for alias in cmd.aliases() {
+                all_commands.push((alias.to_string(), cmd.description().to_string()));
             }
         }
 
@@ -175,13 +114,13 @@ impl CommandAutocomplete {
     pub fn resolve_command(&self, input: &str) -> Option<&'static str> {
         let input_lower = input.to_lowercase();
 
-        for cmd in COMMANDS {
-            if cmd.command == input_lower {
-                return Some(cmd.command);
+        for command in SlashCommand::all() {
+            if command.command() == input_lower {
+                return Some(command.command());
             }
-            for alias in cmd.aliases {
+            for alias in command.aliases() {
                 if *alias == input_lower {
-                    return Some(cmd.command);
+                    return Some(command.command());
                 }
             }
         }
@@ -190,9 +129,9 @@ impl CommandAutocomplete {
 
     /// Get all available commands (for help display)
     pub fn all_commands(&self) -> Vec<(&'static str, &'static str)> {
-        COMMANDS
+        SlashCommand::all()
             .iter()
-            .map(|c| (c.command, c.description))
+            .map(|command| (command.command(), command.description()))
             .collect()
     }
 
@@ -278,9 +217,9 @@ impl inquire::Autocomplete for SlashCommandSuggester {
 
 /// Get all commands as formatted strings for display
 pub fn get_all_command_options() -> Vec<String> {
-    COMMANDS
+    SlashCommand::all()
         .iter()
-        .map(|c| format!("{} - {}", c.command, c.description))
+        .map(|command| format!("{} - {}", command.command(), command.description()))
         .collect()
 }
 

--- a/src/cli_logic/cli_logic_interactive.rs
+++ b/src/cli_logic/cli_logic_interactive.rs
@@ -1,6 +1,7 @@
 use crate::cli_logic::cli_logic_autocomplete::{get_autocomplete, SlashCommandSuggester};
 use crate::cli_logic::cli_logic_first_run::{is_first_run, run_first_time_wizard};
 use crate::cli_logic::cli_logic_welcome::display_welcome_screen;
+use crate::cli_logic::command::SlashCommand;
 use crate::cli_logic::themed_components::get_autocomplete_config;
 use crate::db::core::connection::DatabaseManager;
 use crate::installation_arguments::InstallationManager;
@@ -117,81 +118,93 @@ async fn execute_command(
     theme: &crate::theme::Theme,
     npm_available: bool,
 ) -> Result<bool> {
-    match selection {
-        "/tools" => {
+    let Ok((command, args)) = SlashCommand::parse_input(selection) else {
+        return execute_non_slash_input(selection, theme, npm_available).await;
+    };
+
+    if !args.is_empty() && !command.accepts_arguments() {
+        return execute_non_slash_input(selection, theme, npm_available).await;
+    }
+
+    match command {
+        SlashCommand::Tools => {
             print!("\x1b[2J\x1b[H");
             handle_ai_tools_menu().await?;
             refresh_screen(theme, npm_available).await?;
         }
-        "/auth" => {
+        SlashCommand::Auth => {
             print!("\x1b[2J\x1b[H");
             crate::cli_logic::handle_authentication_menu().await?;
             refresh_screen(theme, npm_available).await?;
         }
-        "/links" => {
+        SlashCommand::Links => {
             print!("\x1b[2J\x1b[H");
             handle_important_links().await?;
             refresh_screen(theme, npm_available).await?;
         }
-        "/settings" => {
+        SlashCommand::Settings => {
             print!("\x1b[2J\x1b[H");
             handle_manage_tools_menu().await?;
             refresh_screen(theme, npm_available).await?;
         }
-        s if s == "/config" || s.starts_with("/config ") => {
-            let args = s.strip_prefix("/config").unwrap_or("").trim();
+        SlashCommand::Config => {
             crate::cli_logic::handle_config_command(args)?;
         }
-        "/db" => {
+        SlashCommand::Db => {
             print!("\x1b[2J\x1b[H");
             crate::cli_logic::handle_db_menu().await?;
             refresh_screen(theme, npm_available).await?;
         }
-        "/theme" => {
+        SlashCommand::Theme => {
             print!("\x1b[2J\x1b[H");
             handle_theme_selection().await?;
             refresh_screen(theme, npm_available).await?;
         }
-        "/dashboard" | "/status" => {
+        SlashCommand::Dashboard => {
             print!("\x1b[2J\x1b[H");
             crate::cli_logic::cli_logic_dashboard::handle_dashboard().await?;
             refresh_screen(theme, npm_available).await?;
         }
-        "/exit" | "/quit" => {
+        SlashCommand::Exit => {
             print!("{}", theme.reset());
             print!("\x1b[0m");
             print!("\x1b[2J\x1b[H");
             println!("Goodbye!");
             return Ok(true);
         }
-        "/help" => {
+        SlashCommand::Help => {
             display_available_commands(theme);
         }
-        _ => {
-            // Check if the input is a known tool name typed directly (without /run).
-            // This lets users type e.g. "claude" or "gemini" to launch a tool
-            // immediately, matching the headless invocation pattern:
-            //   terminal-jarvis claude
-            let candidate = selection.trim().to_lowercase();
-            let known_tools = crate::installation_arguments::InstallationManager::get_tool_names();
-            if known_tools.iter().any(|t| t.to_lowercase() == candidate) {
-                match crate::cli_logic::cli_logic_tool_execution::handle_run_tool(&candidate, &[])
-                    .await
-                {
-                    Ok(_) => {}
-                    Err(e) => eprintln!("\n{} {}", theme.accent("[!]"), e),
-                }
-                refresh_screen(theme, npm_available).await?;
-            } else {
-                println!("\n{} Unknown command: {}", theme.accent("[!]"), selection);
-                println!(
-                    "Type {} for tools or {} for commands",
-                    theme.accent("/tools"),
-                    theme.accent("/help")
-                );
-            }
-        }
     }
+    Ok(false)
+}
+
+async fn execute_non_slash_input(
+    selection: &str,
+    theme: &crate::theme::Theme,
+    npm_available: bool,
+) -> Result<bool> {
+    // Check if the input is a known tool name typed directly (without /run).
+    // This lets users type e.g. "claude" or "gemini" to launch a tool
+    // immediately, matching the headless invocation pattern:
+    //   terminal-jarvis claude
+    let candidate = selection.trim().to_lowercase();
+    let known_tools = crate::installation_arguments::InstallationManager::get_tool_names();
+    if known_tools.iter().any(|t| t.to_lowercase() == candidate) {
+        match crate::cli_logic::cli_logic_tool_execution::handle_run_tool(&candidate, &[]).await {
+            Ok(_) => {}
+            Err(e) => eprintln!("\n{} {}", theme.accent("[!]"), e),
+        }
+        refresh_screen(theme, npm_available).await?;
+    } else {
+        println!("\n{} Unknown command: {}", theme.accent("[!]"), selection);
+        println!(
+            "Type {} for tools or {} for commands",
+            theme.accent("/tools"),
+            theme.accent("/help")
+        );
+    }
+
     Ok(false)
 }
 
@@ -223,88 +236,35 @@ fn display_available_commands(theme: &crate::theme::Theme) {
         "Minimal" => {
             // Ultra-minimal: no colors, just aligned text
             println!("Commands:");
-            println!("  /tools      AI CLI Tools");
-            println!("  /auth       Authentication");
-            println!("  /links      Important Links");
-            println!("  /settings   Settings");
-            println!("  /config     Configuration Path");
-            println!("  /db         Database Management");
-            println!("  /theme      Change UI Theme");
-            println!("  /dashboard  Tool Health Status");
-            println!("  /help       Show this help");
-            println!("  /exit       Exit");
+            for command in SlashCommand::all() {
+                println!("  {:<11} {}", command.command(), command.description());
+            }
             println!();
             println!("Tab to autocomplete");
         }
         "Terminal" => {
             // Hacker aesthetic: clean table format
             println!("{}", theme.primary("[COMMANDS]"));
-            println!(
-                "  {} {}",
-                theme.accent("/tools"),
-                theme.secondary("Launch AI coding assistants")
-            );
-            println!(
-                "  {} {}",
-                theme.accent("/auth"),
-                theme.secondary("Manage API credentials")
-            );
-            println!(
-                "  {} {}",
-                theme.accent("/links"),
-                theme.secondary("Documentation & resources")
-            );
-            println!(
-                "  {} {}",
-                theme.accent("/settings"),
-                theme.secondary("Install/update/configure")
-            );
-            println!(
-                "  {} {}",
-                theme.accent("/config"),
-                theme.secondary("Manage configuration path")
-            );
-            println!(
-                "  {} {}",
-                theme.accent("/db"),
-                theme.secondary("Database operations")
-            );
-            println!(
-                "  {} {}",
-                theme.accent("/theme"),
-                theme.secondary("Switch visual theme")
-            );
-            println!(
-                "  {} {}",
-                theme.accent("/dashboard"),
-                theme.secondary("Tool health status")
-            );
-            println!(
-                "  {} {}",
-                theme.accent("/help"),
-                theme.secondary("Display this command list")
-            );
-            println!(
-                "  {} {}",
-                theme.accent("/exit"),
-                theme.secondary("Terminate session")
-            );
+            for command in SlashCommand::all() {
+                println!(
+                    "  {} {}",
+                    theme.accent(command.command()),
+                    theme.secondary(command.description())
+                );
+            }
             println!();
             println!("{}", theme.secondary("Tab to autocomplete"));
         }
         _ => {
             // Default TJarvis: Clean, modern layout
             println!("{}", theme.accent("Commands:"));
-            println!("  {} - AI CLI Tools", theme.secondary("/tools"));
-            println!("  {} - Authentication", theme.secondary("/auth"));
-            println!("  {} - Important Links", theme.secondary("/links"));
-            println!("  {} - Settings", theme.secondary("/settings"));
-            println!("  {} - Configuration Path", theme.secondary("/config"));
-            println!("  {} - Database Management", theme.secondary("/db"));
-            println!("  {} - Change UI Theme", theme.secondary("/theme"));
-            println!("  {} - Tool Health Status", theme.secondary("/dashboard"));
-            println!("  {} - Show this help", theme.secondary("/help"));
-            println!("  {} - Exit", theme.secondary("/exit"));
+            for command in SlashCommand::all() {
+                println!(
+                    "  {} - {}",
+                    theme.secondary(command.command()),
+                    command.description()
+                );
+            }
             println!();
             println!("{}", theme.secondary("Tab to autocomplete"));
         }

--- a/src/cli_logic/command.rs
+++ b/src/cli_logic/command.rs
@@ -1,0 +1,153 @@
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlashCommand {
+    Tools,
+    Auth,
+    Links,
+    Settings,
+    Config,
+    Db,
+    Theme,
+    Dashboard,
+    Help,
+    Exit,
+}
+
+impl SlashCommand {
+    pub const fn all() -> &'static [Self] {
+        &[
+            Self::Tools,
+            Self::Auth,
+            Self::Links,
+            Self::Settings,
+            Self::Config,
+            Self::Db,
+            Self::Theme,
+            Self::Dashboard,
+            Self::Help,
+            Self::Exit,
+        ]
+    }
+
+    pub const fn command(self) -> &'static str {
+        match self {
+            Self::Tools => "/tools",
+            Self::Auth => "/auth",
+            Self::Links => "/links",
+            Self::Settings => "/settings",
+            Self::Config => "/config",
+            Self::Db => "/db",
+            Self::Theme => "/theme",
+            Self::Dashboard => "/dashboard",
+            Self::Help => "/help",
+            Self::Exit => "/exit",
+        }
+    }
+
+    pub const fn description(self) -> &'static str {
+        match self {
+            Self::Tools => "AI CLI Tools",
+            Self::Auth => "Authentication",
+            Self::Links => "Important Links",
+            Self::Settings => "Settings",
+            Self::Config => "Configuration Path",
+            Self::Db => "Database Management",
+            Self::Theme => "Change UI Theme",
+            Self::Dashboard => "Tool Health Dashboard",
+            Self::Help => "Show help",
+            Self::Exit => "Exit",
+        }
+    }
+
+    pub const fn aliases(self) -> &'static [&'static str] {
+        match self {
+            Self::Dashboard => &["/status"],
+            Self::Exit => &["/quit"],
+            _ => &[],
+        }
+    }
+
+    pub const fn accepts_arguments(self) -> bool {
+        matches!(self, Self::Config)
+    }
+
+    pub fn parse_input(input: &str) -> Result<(Self, &str), String> {
+        let trimmed = input.trim();
+        let Some((command, args)) = trimmed.split_once(char::is_whitespace) else {
+            return trimmed.parse().map(|command| (command, ""));
+        };
+
+        command.parse().map(|command| (command, args.trim()))
+    }
+}
+
+impl fmt::Display for SlashCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.command())
+    }
+}
+
+impl FromStr for SlashCommand {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let input = input.trim().to_lowercase();
+        for command in Self::all() {
+            if input == command.command() || command.aliases().contains(&input.as_str()) {
+                return Ok(*command);
+            }
+        }
+
+        Err(format!("Unknown command: {input}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_canonical_commands() {
+        assert_eq!(
+            "/tools".parse::<SlashCommand>().unwrap(),
+            SlashCommand::Tools
+        );
+        assert_eq!(
+            "/config".parse::<SlashCommand>().unwrap(),
+            SlashCommand::Config
+        );
+    }
+
+    #[test]
+    fn parses_aliases_to_canonical_variants() {
+        assert_eq!(
+            "/status".parse::<SlashCommand>().unwrap(),
+            SlashCommand::Dashboard
+        );
+        assert_eq!("/quit".parse::<SlashCommand>().unwrap(), SlashCommand::Exit);
+    }
+
+    #[test]
+    fn parse_input_preserves_arguments() {
+        let (command, args) = SlashCommand::parse_input("/config ./custom.toml").unwrap();
+
+        assert_eq!(command, SlashCommand::Config);
+        assert_eq!(args, "./custom.toml");
+    }
+
+    #[test]
+    fn only_config_accepts_arguments() {
+        assert!(SlashCommand::Config.accepts_arguments());
+        assert!(!SlashCommand::Help.accepts_arguments());
+        assert!(!SlashCommand::Tools.accepts_arguments());
+    }
+
+    #[test]
+    fn all_commands_have_descriptions() {
+        assert!(SlashCommand::all()
+            .iter()
+            .all(|command| !command.description().is_empty()));
+    }
+}

--- a/src/cli_logic/mod.rs
+++ b/src/cli_logic/mod.rs
@@ -18,6 +18,7 @@ pub mod cli_logic_tool_execution;
 pub mod cli_logic_update_operations;
 pub mod cli_logic_utilities;
 pub mod cli_logic_welcome;
+pub mod command;
 pub mod themed_components;
 
 // Re-export main public functions for backward compatibility


### PR DESCRIPTION
## Summary
- add a `SlashCommand` enum for canonical slash commands, aliases, descriptions, and argument handling
- use the enum as the autocomplete source of truth
- route interactive slash command dispatch through enum variants while preserving direct tool-name fallback

## Tests
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked cli_logic::command`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked cli_logic::cli_logic_autocomplete`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= ./scripts/verify/verify-change.sh --quick`

Closes #57
