### PR TITLE
ci: prevent repo-local docs directory

### DIFF
--- a/.github/workflows/no-repo-docs.yml
+++ b/.github/workflows/no-repo-docs.yml
@@ -1,0 +1,25 @@
+name: Repository Docs Guard
+
+on:
+  push:
+    branches: ["main", "develop"]
+  pull_request:
+    branches: ["main", "develop"]
+
+permissions:
+  contents: read
+
+jobs:
+  no-repo-docs:
+    name: Prevent top-level docs directory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Reject repo-local docs directory
+        run: |
+          if [ -d docs ]; then
+            echo "::error::Do not add a top-level docs/ directory to terminal-jarvis. Project docs live in my-life-as-a-dev."
+            find docs -maxdepth 3 -type f | sort
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add a dedicated docs guard workflow with no path-ignore rules
- fail PR and develop/main push checks if a top-level `docs/` directory exists
- keep Terminal Jarvis docs in `my-life-as-a-dev` instead of this repo

## Verification
- `test ! -d docs && echo "no top-level docs directory"`
- `/usr/bin/git diff --check`
- `/usr/bin/git ls-tree -r --name-only origin/develop | rg '^docs/' || true`

