### PR TITLE
refactor(cli): flatten tool install flow

### DIFF
--- a/src/cli_logic/cli_logic_entry_point.rs
+++ b/src/cli_logic/cli_logic_entry_point.rs
@@ -92,74 +92,17 @@ async fn handle_tool_launch(tool_name: &str) -> Result<()> {
 
     // Use async version that checks database first
     let tools = ToolManager::get_available_tools_async().await;
-    let tool_info = match tools.get(tool_name) {
-        Some(info) => info,
-        None => {
-            println!(
-                "\n{}: Tool '{}' not found in available tools",
-                theme.accent("Error"),
-                tool_name
-            );
-            return Ok(());
-        }
+    let Some(tool_info) = tools.get(tool_name) else {
+        println!(
+            "\n{}: Tool '{}' not found in available tools",
+            theme.accent("Error"),
+            tool_name
+        );
+        return Ok(());
     };
 
-    if !tool_info.is_installed {
-        // Check if required package manager is available before prompting install
-        if !tool_info.package_manager.is_available() {
-            let pm_label = tool_info.package_manager.label();
-            let install_hint = tool_info.package_manager.install_hint();
-
-            println!(
-                "\n{}",
-                theme.accent(&format!(
-                    "Cannot install '{}': {} is not available on your system.",
-                    tool_name, pm_label
-                ))
-            );
-            println!("{}", theme.secondary(install_hint));
-            println!("\n{}", theme.secondary("Press Enter to continue..."));
-            let _ = std::io::stdin().read_line(&mut String::new());
-            return Ok(());
-        }
-
-        let should_install = match themed_confirm(&format!(
-            "{} '{}' is not installed. Install it now?",
-            theme.accent("Tool"),
-            tool_name
-        ))
-        .with_default(true)
-        .prompt()
-        {
-            Ok(result) => result,
-            Err(_) => {
-                // User interrupted - go back to main menu
-                println!("\n{}", theme.accent("Installation cancelled"));
-                return Ok(());
-            }
-        };
-
-        if should_install {
-            println!("\n{}", theme.accent(&format!("Installing {tool_name}...")));
-            match handle_install_tool(tool_name).await {
-                Ok(_) => {
-                    println!("{}", theme.accent("Installation complete!\n"));
-                }
-                Err(e) => {
-                    // Show error gracefully and return to menu instead of crashing
-                    println!("\n{}", theme.accent(&format!("Installation failed: {e}")));
-                    println!(
-                        "{}",
-                        theme.secondary("You can try again or check the requirements.")
-                    );
-                    println!("\n{}", theme.secondary("Press Enter to continue..."));
-                    let _ = std::io::stdin().read_line(&mut String::new());
-                    return Ok(());
-                }
-            }
-        } else {
-            return Ok(());
-        }
+    if !tool_info.is_installed && !install_missing_tool_if_requested(tool_name, tool_info).await? {
+        return Ok(());
     }
 
     // Issue #26 Fix: Skip args prompt - launch immediately with defaults
@@ -170,6 +113,86 @@ async fn handle_tool_launch(tool_name: &str) -> Result<()> {
     // Always launch the tool and show post-tool menu regardless of success/failure
     let _result = launch_tool_with_progress(tool_name, &args).await;
     handle_post_tool_exit(tool_name, &args).await
+}
+
+async fn install_missing_tool_if_requested(
+    tool_name: &str,
+    tool_info: &crate::tools::ToolInfo,
+) -> Result<bool> {
+    let theme = theme_global_config::current_theme();
+    if !tool_info.package_manager.is_available() {
+        let pm_label = tool_info.package_manager.label();
+        let install_hint = tool_info.package_manager.install_hint();
+
+        println!(
+            "\n{}",
+            theme.accent(&format!(
+                "Cannot install '{}': {} is not available on your system.",
+                tool_name, pm_label
+            ))
+        );
+        println!("{}", theme.secondary(install_hint));
+        wait_for_enter(&theme);
+        return Ok(false);
+    }
+
+    let should_install = match themed_confirm(&format!(
+        "{} '{}' is not installed. Install it now?",
+        theme.accent("Tool"),
+        tool_name
+    ))
+    .with_default(true)
+    .prompt()
+    {
+        Ok(result) => result,
+        Err(_) => {
+            println!("\n{}", theme.accent("Installation cancelled"));
+            return Ok(false);
+        }
+    };
+
+    if !should_install {
+        return Ok(false);
+    }
+
+    println!("\n{}", theme.accent(&format!("Installing {tool_name}...")));
+    if let Err(e) = handle_install_tool(tool_name).await {
+        println!("\n{}", theme.accent(&format!("Installation failed: {e}")));
+        println!(
+            "{}",
+            theme.secondary("You can try again or check the requirements.")
+        );
+        wait_for_enter(&theme);
+        return Ok(false);
+    }
+
+    println!("{}", theme.accent("Installation complete!\n"));
+    Ok(true)
+}
+
+fn wait_for_enter(theme: &crate::theme::Theme) {
+    println!("\n{}", theme.secondary("Press Enter to continue..."));
+    let _ = std::io::stdin().read_line(&mut String::new());
+}
+
+fn command_exists(command: &str) -> bool {
+    std::process::Command::new("which")
+        .arg(command)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn apt_get_install_command() -> tokio::process::Command {
+    use tokio::process::Command as AsyncCommand;
+
+    if command_exists("sudo") {
+        let mut command = AsyncCommand::new("sudo");
+        command.arg("apt-get");
+        command
+    } else {
+        AsyncCommand::new("apt-get")
+    }
 }
 
 /// Launch a tool with progress tracking
@@ -516,156 +539,167 @@ async fn handle_theme_switch_menu() -> Result<()> {
 }
 
 // Additional menu handlers will be moved to separate domain files as the refactoring continues
-async fn handle_install_tools_menu() -> Result<()> {
-    // Implementation moved to a focused module - placeholder for now
+async fn check_npm_for_install_menu() -> bool {
     use crate::progress_utils::ProgressUtils;
 
-    // Check installer prerequisites with progress (npm, uv, curl).
-    // NOTE: A missing npm is a WARNING, not a hard stop. Curl/uv tools are
-    // still installable without npm. We filter out npm tools below when npm
-    // is unavailable so users can still install everything else.
     let npm_check = ProgressContext::new("Checking NPM availability");
     tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
     let npm_available = InstallationManager::check_npm_available();
-    if !npm_available {
-        npm_check.finish_error("Node.js not available - npm tools cannot be installed");
-        ProgressUtils::info_message(
-            "Install Node.js from: https://nodejs.org/ to enable npm-based tools",
-        );
-    } else {
+
+    if npm_available {
         npm_check.finish_success("NPM is available");
+        return true;
     }
+
+    npm_check.finish_error("Node.js not available - npm tools cannot be installed");
+    ProgressUtils::info_message(
+        "Install Node.js from: https://nodejs.org/ to enable npm-based tools",
+    );
+    false
+}
+
+async fn ensure_curl_for_install_menu() {
+    use crate::progress_utils::ProgressUtils;
 
     let curl_check = ProgressContext::new("Checking curl availability");
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
     if InstallationManager::check_curl_available() {
         curl_check.finish_success("curl is available");
-    } else {
-        curl_check.finish_error("curl not found");
-        ProgressUtils::info_message(
-            "Some tools (e.g., Goose) use curl-based installers. Please install curl via your package manager.",
-        );
-        // Optional: Offer auto-install via apt-get if available
-        let apt_exists = std::process::Command::new("which")
-            .arg("apt-get")
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false);
-        if apt_exists
-            && themed_confirm("Install curl now using apt-get?")
-                .with_default(false)
-                .prompt()
-                .unwrap_or(false)
-        {
-            let sudo_available = std::process::Command::new("which")
-                .arg("sudo")
-                .output()
-                .map(|o| o.status.success())
-                .unwrap_or(false);
-            use tokio::process::Command as AsyncCommand;
-            let mut install = if sudo_available {
-                let mut c = AsyncCommand::new("sudo");
-                c.arg("apt-get");
-                c
-            } else {
-                AsyncCommand::new("apt-get")
-            };
-            let _ = install
-                .args(["update"]) // update first (best effort)
-                .status()
-                .await;
-            let mut install = if sudo_available {
-                let mut c = AsyncCommand::new("sudo");
-                c.arg("apt-get");
-                c
-            } else {
-                AsyncCommand::new("apt-get")
-            };
-            let status = install
-                .args(["install", "-y", "curl"]) // non-interactive
-                .status()
-                .await;
-            match status {
-                Ok(s) if s.success() => ProgressUtils::success_message("curl installed."),
-                _ => ProgressUtils::error_message("Failed to install curl with apt-get."),
-            }
-        }
+        return;
     }
+
+    curl_check.finish_error("curl not found");
+    ProgressUtils::info_message(
+        "Some tools (e.g., Goose) use curl-based installers. Please install curl via your package manager.",
+    );
+
+    if !command_exists("apt-get") {
+        return;
+    }
+
+    let should_install = themed_confirm("Install curl now using apt-get?")
+        .with_default(false)
+        .prompt()
+        .unwrap_or(false);
+    if !should_install {
+        return;
+    }
+
+    install_curl_with_apt_get().await;
+}
+
+async fn install_curl_with_apt_get() {
+    use crate::progress_utils::ProgressUtils;
+
+    let _ = apt_get_install_command().args(["update"]).status().await;
+    let status = apt_get_install_command()
+        .args(["install", "-y", "curl"])
+        .status()
+        .await;
+
+    match status {
+        Ok(status) if status.success() => ProgressUtils::success_message("curl installed."),
+        _ => ProgressUtils::error_message("Failed to install curl with apt-get."),
+    }
+}
+
+async fn ensure_uv_for_install_menu() {
+    use crate::progress_utils::ProgressUtils;
 
     let uv_check = ProgressContext::new("Checking uv availability");
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-    let uv_available = InstallationManager::check_uv_available();
-    if uv_available {
+    if InstallationManager::check_uv_available() {
         uv_check.finish_success("uv is available");
-    } else {
-        uv_check.finish_error("uv not found");
-        ProgressUtils::info_message(
-            "Some tools (e.g., Aider) use uv for installation. Install uv: https://docs.astral.sh/uv/getting-started/installation/",
-        );
-        // Offer to install uv automatically if curl is available
-        if InstallationManager::check_curl_available()
-            && themed_confirm("Install uv now via official script?")
-                .with_default(false)
-                .prompt()
-                .unwrap_or(false)
-        {
-            // Download and run uv installer: curl -LsSf https://astral.sh/uv/install.sh | sh
-            use tokio::process::Command as AsyncCommand;
-            let url = "https://astral.sh/uv/install.sh";
-            let curl_output = AsyncCommand::new("curl")
-                .args(["-LsSf", url])
-                .output()
-                .await;
-            match curl_output {
-                Ok(out) if out.status.success() => {
-                    let mut sh = AsyncCommand::new("sh");
-                    sh.stdin(std::process::Stdio::piped());
-                    sh.stdout(std::process::Stdio::null());
-                    sh.stderr(std::process::Stdio::null());
-                    if let Ok(mut child) = sh.spawn() {
-                        if let Some(stdin) = child.stdin.as_mut() {
-                            use tokio::io::AsyncWriteExt;
-                            let _ = stdin.write_all(&out.stdout).await;
-                        }
-                        let _ = child.wait().await;
-                    }
-                    // Re-check availability
-                    if InstallationManager::check_uv_available() {
-                        ProgressUtils::success_message("uv installed successfully. You may need to restart your shell for PATH updates.");
-                    } else {
-                        ProgressUtils::warning_message("uv installation finished but not detected on PATH yet. Try restarting your terminal.");
-                    }
-                }
-                _ => {
-                    ProgressUtils::error_message(
-                        "Failed to download uv installer. See docs link above.",
-                    );
-                }
-            }
-        }
+        return;
     }
+
+    uv_check.finish_error("uv not found");
+    ProgressUtils::info_message(
+        "Some tools (e.g., Aider) use uv for installation. Install uv: https://docs.astral.sh/uv/getting-started/installation/",
+    );
+
+    let should_install = InstallationManager::check_curl_available()
+        && themed_confirm("Install uv now via official script?")
+            .with_default(false)
+            .prompt()
+            .unwrap_or(false);
+    if !should_install {
+        return;
+    }
+
+    install_uv_with_official_script().await;
+}
+
+async fn install_uv_with_official_script() {
+    use crate::progress_utils::ProgressUtils;
+    use tokio::process::Command as AsyncCommand;
+
+    let curl_output = AsyncCommand::new("curl")
+        .args(["-LsSf", "https://astral.sh/uv/install.sh"])
+        .output()
+        .await;
+    let Ok(output) = curl_output else {
+        ProgressUtils::error_message("Failed to download uv installer. See docs link above.");
+        return;
+    };
+
+    if !output.status.success() {
+        ProgressUtils::error_message("Failed to download uv installer. See docs link above.");
+        return;
+    }
+
+    let mut shell = AsyncCommand::new("sh");
+    shell.stdin(std::process::Stdio::piped());
+    shell.stdout(std::process::Stdio::null());
+    shell.stderr(std::process::Stdio::null());
+    if let Ok(mut child) = shell.spawn() {
+        if let Some(stdin) = child.stdin.as_mut() {
+            use tokio::io::AsyncWriteExt;
+            let _ = stdin.write_all(&output.stdout).await;
+        }
+        let _ = child.wait().await;
+    }
+
+    if InstallationManager::check_uv_available() {
+        ProgressUtils::success_message(
+            "uv installed successfully. You may need to restart your shell for PATH updates.",
+        );
+    } else {
+        ProgressUtils::warning_message(
+            "uv installation finished but not detected on PATH yet. Try restarting your terminal.",
+        );
+    }
+}
+
+fn filter_installable_tools(tools: Vec<String>, npm_available: bool) -> Vec<String> {
+    if npm_available {
+        return tools;
+    }
+
+    tools
+        .into_iter()
+        .filter(|tool| {
+            InstallationManager::get_install_command(tool)
+                .map(|command| !command.requires_npm)
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+async fn handle_install_tools_menu() -> Result<()> {
+    // Implementation moved to a focused module - placeholder for now
+    use crate::progress_utils::ProgressUtils;
+
+    let npm_available = check_npm_for_install_menu().await;
+    ensure_curl_for_install_menu().await;
+    ensure_uv_for_install_menu().await;
 
     // Check which tools are uninstalled with progress
     let check_progress = ProgressContext::new("Scanning for uninstalled tools");
     tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
 
-    let all_uninstalled = ToolManager::get_uninstalled_tools();
-
-    // When npm is unavailable, exclude npm-dependent tools so users can still
-    // install curl/uv tools. This is the key behaviour: prefer native downloads
-    // (curl) and don't block the whole menu on a missing npm.
-    let uninstalled_tools: Vec<String> = if npm_available {
-        all_uninstalled
-    } else {
-        all_uninstalled
-            .into_iter()
-            .filter(|tool| {
-                InstallationManager::get_install_command(tool)
-                    .map(|cmd| !cmd.requires_npm)
-                    .unwrap_or(false)
-            })
-            .collect()
-    };
+    let uninstalled_tools =
+        filter_installable_tools(ToolManager::get_uninstalled_tools(), npm_available);
 
     if uninstalled_tools.is_empty() {
         if npm_available {
@@ -810,5 +844,26 @@ mod tests {
             options,
             vec!["Reopen __missing_tool__", "Back to Home", "Exit"]
         );
+    }
+
+    #[test]
+    fn filter_installable_tools_keeps_all_tools_when_npm_is_available() {
+        let tools = vec!["claude".to_string(), "goose".to_string()];
+
+        assert_eq!(filter_installable_tools(tools.clone(), true), tools);
+    }
+
+    #[test]
+    fn filter_installable_tools_hides_npm_tools_when_npm_is_unavailable() {
+        let tools = vec![
+            "gemini".to_string(),
+            "goose".to_string(),
+            "aider".to_string(),
+        ];
+        let filtered = filter_installable_tools(tools, false);
+
+        assert!(!filtered.contains(&"gemini".to_string()));
+        assert!(filtered.contains(&"goose".to_string()));
+        assert!(filtered.contains(&"aider".to_string()));
     }
 }


### PR DESCRIPTION
## Summary
- flatten missing-tool launch handling with early returns
- extract install-menu prerequisite checks into focused helper functions
- add focused coverage for npm-unavailable install filtering

## Tests
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --locked cli_logic::cli_logic_entry_point`
- `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= ./scripts/verify/verify-change.sh --quick`
- merge-tree simulation with #98 passed

Closes #56
