### PR TITLE
fix(readme): point coverage badge to ci reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,12 @@ jobs:
           cargo install cargo-tarpaulin
         fi
         # Generate coverage report (xml for upload, stdout for logs)
-        cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml --out Stdout 2>&1 | head -100 || true
+        set +e
+        cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml --out Stdout > tarpaulin.log 2>&1
+        tarpaulin_status=$?
+        set -e
+        head -100 tarpaulin.log
+        exit "$tarpaulin_status"
       continue-on-error: true
 
     - name: Upload coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       with:
         name: rust-coverage-report
         path: cobertura.xml
-        if-no-files-found: warn
+        if-no-files-found: error
         retention-days: 14
 
     # Go code quality + tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,15 @@ jobs:
         cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml --out Stdout 2>&1 | head -100 || true
       continue-on-error: true
 
+    - name: Upload coverage report
+      if: ${{ matrix.suite == 'rust' }}
+      uses: actions/upload-artifact@v6
+      with:
+        name: rust-coverage-report
+        path: cobertura.xml
+        if-no-files-found: warn
+        retention-days: 14
+
     # Go code quality + tests
     - name: Setup Go
       if: ${{ matrix.suite == 'go' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - **Release Review Follow-Up**: Hardened environment-mutating tests with panic-safe restoration, clarified custom config load failures, aligned ADK version display, and improved tool catalog assertion diagnostics.
+- **Coverage Badge Link**: Updated the root README coverage badge to point at the CI workflow that produces the coverage report artifact.
 
 ## [0.0.82] - 2026-05-14
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Manage Claude, Gemini, Qwen, and 22 more AI assistants from one terminal interfa
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![Mentioned in Awesome](https://img.shields.io/badge/Mentioned%20in-Awesome-6f42c1?style=flat-square)](https://github.com/Piebald-AI/awesome-gemini-cli)
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square)](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/)
-[![Coverage](https://img.shields.io/badge/coverage-report-green.svg?style=flat-square)](/coverage)
+[![Coverage](https://img.shields.io/badge/coverage-report-green.svg?style=flat-square)](https://github.com/BA-CalderonMorales/terminal-jarvis/actions/workflows/ci.yml?query=branch%3Adevelop)
 
 <img src="https://raw.githubusercontent.com/BA-CalderonMorales/terminal-jarvis/docs/screenshots_and_demos/screenshots_and_demo/promo_image_for_readme.png" alt="Terminal Jarvis Interface" width="100%">
 

--- a/npm/terminal-jarvis/README.md
+++ b/npm/terminal-jarvis/README.md
@@ -12,7 +12,7 @@ Manage Claude, Gemini, Qwen, and 22 more AI assistants from one terminal interfa
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![Mentioned in Awesome](https://img.shields.io/badge/Mentioned%20in-Awesome-6f42c1?style=flat-square)](https://github.com/Piebald-AI/awesome-gemini-cli)
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square)](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/)
-[![Coverage](https://img.shields.io/badge/coverage-report-green.svg?style=flat-square)](/coverage)
+[![Coverage](https://img.shields.io/badge/coverage-report-green.svg?style=flat-square)](https://github.com/BA-CalderonMorales/terminal-jarvis/actions/workflows/ci.yml?query=branch%3Adevelop)
 
 <img src="https://raw.githubusercontent.com/BA-CalderonMorales/terminal-jarvis/docs/screenshots_and_demos/screenshots_and_demo/promo_image_for_readme.png" alt="Terminal Jarvis Interface" width="100%">
 


### PR DESCRIPTION
## Summary

- replace the broken root README `/coverage` badge target with the CI workflow page that generates coverage
- upload `cobertura.xml` from the Rust coverage job as a retained workflow artifact
- keep the npm package README badge copy aligned with the root README

## Verification

- `/usr/bin/git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parses"'`
- `curl -I -L --max-time 20 'https://github.com/BA-CalderonMorales/terminal-jarvis/actions/workflows/ci.yml?query=branch%3Adevelop'`
- `curl -I -L --max-time 20 'https://img.shields.io/badge/coverage-report-green.svg?style=flat-square'`

## Notes

- Addresses #109.
- The same README fix will reach `main` through the next normal `develop` to `main` sync.
- No top-level `docs/` directory was added.
