### PR TITLE
feat(devex): benchmark install latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Install Latency Benchmarks**: Added a repeatable npm/npx, Homebrew, and cargo install latency benchmark harness with WSL context capture and phase-oriented logs.
+
 ### Changed
 - **Release Review Gates**: Aligned npm CI/CD workflows to Node 20+ with engine-strict installs so dependency engine drift is caught before release or main sync.
 
 ### Fixed
 - **Release Review Follow-Up**: Hardened environment-mutating tests with panic-safe restoration, clarified custom config load failures, aligned ADK version display, and improved tool catalog assertion diagnostics.
 - **Coverage Badge Link**: Updated the root README coverage badge to point at the CI workflow that produces the coverage report artifact.
+- **NPM Postinstall Latency**: Drained GitHub release redirect responses during binary downloads so Node does not wait on stale sockets after the installer reports success.
 
 ## [0.0.82] - 2026-05-14
 

--- a/npm/terminal-jarvis/scripts/postinstall.js
+++ b/npm/terminal-jarvis/scripts/postinstall.js
@@ -100,7 +100,7 @@ async function download(url, dest, retries = DOWNLOAD_RETRIES) {
                     https.get(requestUrl, (res) => {
                         // Handle redirects (GitHub uses them for releases)
                         if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-                            clearTimeout(timeout);
+                            res.resume();
                             return makeRequest(res.headers.location);
                         }
 
@@ -346,5 +346,6 @@ module.exports = {
     getPlatformInfo,
     getAssetUrl,
     checkPrerequisites,
+    download,
     main
 };

--- a/npm/terminal-jarvis/tests/postinstall-download.test.ts
+++ b/npm/terminal-jarvis/tests/postinstall-download.test.ts
@@ -1,0 +1,71 @@
+import { PassThrough } from "stream";
+import { mkdtemp, readFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const https = require("https");
+const { download } = require("../scripts/postinstall.js");
+
+describe("postinstall download", () => {
+  const originalGet = https.get;
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    https.get = originalGet;
+    vi.restoreAllMocks();
+
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  test("drains GitHub redirect responses before following asset URL", async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "terminal-jarvis-download-"));
+    const destination = path.join(tempDir, "asset.tar.gz");
+    const redirectResume = vi.fn();
+    const seenUrls: string[] = [];
+
+    https.get = vi.fn((url: string, callback: (response: PassThrough) => void) => {
+      seenUrls.push(url);
+
+      const response = new PassThrough() as PassThrough & {
+        statusCode: number;
+        statusMessage: string;
+        headers: Record<string, string>;
+        resume: () => PassThrough;
+      };
+
+      if (seenUrls.length === 1) {
+        response.statusCode = 302;
+        response.statusMessage = "Found";
+        response.headers = { location: "https://downloads.example/asset.tar.gz" };
+        response.resume = vi.fn(() => {
+          redirectResume();
+          return response;
+        });
+        queueMicrotask(() => callback(response));
+      } else {
+        response.statusCode = 200;
+        response.statusMessage = "OK";
+        response.headers = { "content-length": "7" };
+        queueMicrotask(() => {
+          callback(response);
+          response.end("archive");
+        });
+      }
+
+      return { on: vi.fn() };
+    });
+
+    await download("https://github.example/release", destination, 1);
+
+    expect(seenUrls).toEqual([
+      "https://github.example/release",
+      "https://downloads.example/asset.tar.gz",
+    ]);
+    expect(redirectResume).toHaveBeenCalledOnce();
+    await expect(readFile(destination, "utf8")).resolves.toBe("archive");
+  });
+});

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -1,0 +1,40 @@
+# Install Latency Benchmarks
+
+Run the repeatable install benchmark from the repository root:
+
+```bash
+scripts/benchmarks/install-latency.sh
+```
+
+The default run measures cold and warm npm/npx installs plus `cargo install` as
+a baseline using isolated cache, prefix, root, and target directories under
+`tmp/install-latency/`.
+
+Homebrew is opt-in because it modifies the real Homebrew prefix:
+
+```bash
+scripts/benchmarks/install-latency.sh --include-brew --allow-brew-uninstall
+```
+
+Add `--clear-brew-cache` when the machine can safely remove cached Terminal
+Jarvis Homebrew downloads before the cold run.
+
+Outputs:
+
+- `summary.tsv`: per-case duration, exit code, command, and log path.
+- `context.txt`: OS, architecture, WSL distro, Node, npm, Cargo, Rust, and
+  Homebrew versions.
+- `signals.txt`: npm timing log paths plus postinstall and Homebrew phase
+  markers for bottleneck analysis.
+
+Latency targets are printed by `scripts/benchmarks/install-latency.sh --help`.
+
+Fast validation:
+
+```bash
+scripts/benchmarks/test-install-latency.sh
+```
+
+That test covers the generated matrix, context writer, help text, and a mutation
+smoke check that removes an expected benchmark entry and verifies the self-test
+catches it.

--- a/scripts/benchmarks/install-latency.sh
+++ b/scripts/benchmarks/install-latency.sh
@@ -102,6 +102,10 @@ self_test() {
     $'npm\tcold\tnpx-terminal-jarvis@latest\tnpx --yes terminal-jarvis@latest --version' \
     $'npm\tcold\tnpx-terminal-jarvis@beta\tnpx --yes terminal-jarvis@beta --version' \
     $'npm\tcold\tnpx-terminal-jarvis@stable\tnpx --yes terminal-jarvis@stable --version' \
+    $'npm\twarm\tnpx-terminal-jarvis\tnpx --yes terminal-jarvis --version' \
+    $'npm\twarm\tnpx-terminal-jarvis@latest\tnpx --yes terminal-jarvis@latest --version' \
+    $'npm\twarm\tnpx-terminal-jarvis@beta\tnpx --yes terminal-jarvis@beta --version' \
+    $'npm\twarm\tnpx-terminal-jarvis@stable\tnpx --yes terminal-jarvis@stable --version' \
     $'npm\tcold\tnpm-install-g-terminal-jarvis\tnpm install -g terminal-jarvis' \
     $'npm\twarm\tnpm-install-g-terminal-jarvis\tnpm install -g terminal-jarvis' \
     $'cargo\tcold\tcargo-install-terminal-jarvis\tcargo install terminal-jarvis --root <isolated>' \
@@ -195,11 +199,26 @@ require_command() {
   fi
 }
 
+now_ms() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import time
+print(time.time_ns() // 1_000_000)
+PY
+  elif command -v perl >/dev/null 2>&1; then
+    perl -MTime::HiRes=time -e 'printf "%.0f\n", time() * 1000'
+  elif command -v node >/dev/null 2>&1; then
+    node -e 'console.log(Date.now())'
+  else
+    echo $(( $(date +%s) * 1000 ))
+  fi
+}
+
 duration_ms() {
-  local started_ns="$1"
-  local ended_ns
-  ended_ns="$(date +%s%N)"
-  echo $(((ended_ns - started_ns) / 1000000))
+  local started_ms="$1"
+  local ended_ms
+  ended_ms="$(now_ms)"
+  echo $((ended_ms - started_ms))
 }
 
 slugify() {
@@ -251,17 +270,17 @@ run_case() {
   local slug
   slug="$(slugify "$manager-$mode-$name")"
   local log_file="$RUN_DIR/$slug.log"
-  local started_ns
+  local started_ms
   local exit_code=0
   local ms
 
   log "Running [$manager][$mode] $name"
-  started_ns="$(date +%s%N)"
+  started_ms="$(now_ms)"
   set +e
   "$@" > "$log_file" 2>&1
   exit_code=$?
   set -e
-  ms="$(duration_ms "$started_ns")"
+  ms="$(duration_ms "$started_ms")"
 
   printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
     "$manager" "$mode" "$name" "$ms" "$exit_code" "$command_text" "$log_file" >> "$SUMMARY"
@@ -280,14 +299,9 @@ run_npm_matrix() {
   require_command npm
   require_command npx
 
-  reset_npm_dirs
-
-  for mode in cold warm; do
-    if [[ "$mode" == "cold" ]]; then
-      reset_npm_dirs
-    fi
-
-    for package_spec in "${NPM_PACKAGES[@]}"; do
+  for package_spec in "${NPM_PACKAGES[@]}"; do
+    reset_npm_dirs
+    for mode in cold warm; do
       run_case "npm" "$mode" "npx-$package_spec" "npx --yes $package_spec --version" \
         env \
           HOME="$RUN_DIR/npm-home" \
@@ -297,7 +311,10 @@ run_npm_matrix() {
           npm_config_foreground_scripts=true \
           npx --yes "$package_spec" --version
     done
+  done
 
+  reset_npm_dirs
+  for mode in cold warm; do
     run_case "npm" "$mode" "npm-install-g-terminal-jarvis" "npm install -g terminal-jarvis" \
       env \
         HOME="$RUN_DIR/npm-home" \
@@ -346,10 +363,12 @@ run_brew_matrix() {
   fi
 
   for mode in cold warm; do
-    brew uninstall --force terminal-jarvis >/dev/null 2>&1 || true
+    if [[ "$mode" == "cold" ]]; then
+      brew uninstall --force terminal-jarvis >/dev/null 2>&1 || true
 
-    if [[ "$mode" == "cold" && "$CLEAR_BREW_CACHE" == true && -n "$cache_dir" ]]; then
-      rm -f "$cache_dir"/downloads/*terminal-jarvis* "$cache_dir"/*terminal-jarvis* 2>/dev/null || true
+      if [[ "$CLEAR_BREW_CACHE" == true && -n "$cache_dir" ]]; then
+        rm -f "$cache_dir"/downloads/*terminal-jarvis* "$cache_dir"/*terminal-jarvis* 2>/dev/null || true
+      fi
     fi
 
     run_case "homebrew" "$mode" "brew-install-terminal-jarvis" "brew install $formula" \

--- a/scripts/benchmarks/install-latency.sh
+++ b/scripts/benchmarks/install-latency.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DEFAULT_WORK_DIR="$PROJECT_ROOT/tmp/install-latency"
+
+WORK_DIR="$DEFAULT_WORK_DIR"
+RUN_NPM=true
+RUN_CARGO=true
+RUN_BREW=false
+ALLOW_BREW_UNINSTALL=false
+CLEAR_BREW_CACHE=false
+KEEP_WORK_DIR=false
+ACTION="run"
+RUN_LABEL="$(date -u +%Y%m%dT%H%M%SZ)"
+
+NPM_PACKAGES=(
+  "terminal-jarvis"
+  "terminal-jarvis@latest"
+  "terminal-jarvis@beta"
+  "terminal-jarvis@stable"
+)
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/benchmarks/install-latency.sh [options]
+
+Benchmarks cold and warm install latency for Terminal Jarvis release paths.
+Results are written under tmp/install-latency by default.
+
+Default matrix:
+  - npx --yes terminal-jarvis --version
+  - npx --yes terminal-jarvis@latest --version
+  - npx --yes terminal-jarvis@beta --version
+  - npx --yes terminal-jarvis@stable --version
+  - npm install -g terminal-jarvis
+  - cargo install terminal-jarvis
+
+Homebrew is opt-in because it uses the real Homebrew prefix:
+  --include-brew            Run brew install timing.
+  --allow-brew-uninstall    Allow brew uninstall before cold/warm brew runs.
+  --clear-brew-cache        Remove Terminal Jarvis Homebrew cache entries before cold brew run.
+
+Other options:
+  --npm-only                Run only npm/npx benchmarks.
+  --cargo-only              Run only cargo baseline benchmarks.
+  --work-dir PATH           Write benchmark logs and temp install roots under PATH.
+  --keep-work-dir           Keep previous work dir contents before starting.
+  --list-matrix             Print the benchmark matrix without running installs.
+  --self-test               Run fast script self-tests without network installs.
+  -h, --help                Show this help.
+
+Recommended latency targets:
+  - npx warm: under 5s
+  - npm install -g warm: under 10s
+  - npm/npx cold with binary download: under 30s on broadband
+  - Homebrew warm: under 15s after tap metadata is current
+  - Homebrew cold: under 45s when downloading a release archive, not building from source
+  - cargo install baseline: informational, expected to be slower than binary distribution paths
+
+Notes:
+  - npm and cargo run with isolated cache/prefix/root directories.
+  - npm runs with foreground scripts and timing logs enabled so package resolution,
+    download, postinstall, binary download, extraction, chmod/staging, and verification
+    evidence is retained in the per-case logs.
+  - On WSL, the summary records the WSL distro and kernel so Windows WSL Ubuntu
+    measurements can be compared against native Linux/macOS runs.
+EOF
+}
+
+list_matrix() {
+  if [[ "$RUN_NPM" == true ]]; then
+    for mode in cold warm; do
+      for package_spec in "${NPM_PACKAGES[@]}"; do
+        printf "npm\t%s\tnpx-%s\tnpx --yes %s --version\n" "$mode" "$package_spec" "$package_spec"
+      done
+      printf "npm\t%s\tnpm-install-g-terminal-jarvis\tnpm install -g terminal-jarvis\n" "$mode"
+    done
+  fi
+
+  if [[ "$RUN_CARGO" == true ]]; then
+    for mode in cold warm; do
+      printf "cargo\t%s\tcargo-install-terminal-jarvis\tcargo install terminal-jarvis --root <isolated>\n" "$mode"
+    done
+  fi
+
+  if [[ "$RUN_BREW" == true ]]; then
+    for mode in cold warm; do
+      printf "homebrew\t%s\tbrew-install-terminal-jarvis\tbrew install ba-calderonmorales/terminal-jarvis/terminal-jarvis\n" "$mode"
+    done
+  fi
+}
+
+self_test() {
+  local matrix
+  matrix="$(list_matrix)"
+
+  for expected in \
+    $'npm\tcold\tnpx-terminal-jarvis\tnpx --yes terminal-jarvis --version' \
+    $'npm\tcold\tnpx-terminal-jarvis@latest\tnpx --yes terminal-jarvis@latest --version' \
+    $'npm\tcold\tnpx-terminal-jarvis@beta\tnpx --yes terminal-jarvis@beta --version' \
+    $'npm\tcold\tnpx-terminal-jarvis@stable\tnpx --yes terminal-jarvis@stable --version' \
+    $'npm\tcold\tnpm-install-g-terminal-jarvis\tnpm install -g terminal-jarvis' \
+    $'npm\twarm\tnpm-install-g-terminal-jarvis\tnpm install -g terminal-jarvis' \
+    $'cargo\tcold\tcargo-install-terminal-jarvis\tcargo install terminal-jarvis --root <isolated>' \
+    $'cargo\twarm\tcargo-install-terminal-jarvis\tcargo install terminal-jarvis --root <isolated>'
+  do
+    if ! grep -Fxq "$expected" <<< "$matrix"; then
+      echo "[ERROR] Missing benchmark matrix entry: $expected" >&2
+      return 1
+    fi
+  done
+
+  if [[ "$(slugify 'npm cold terminal-jarvis@beta')" != "npm-cold-terminal-jarvis-beta" ]]; then
+    echo "[ERROR] slugify did not produce the expected stable log name" >&2
+    return 1
+  fi
+
+  if ! write_context; then
+    echo "[ERROR] write_context failed" >&2
+    return 1
+  fi
+
+  echo "[install-latency] self-test passed"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --include-brew)
+      RUN_BREW=true
+      shift
+      ;;
+    --allow-brew-uninstall)
+      ALLOW_BREW_UNINSTALL=true
+      shift
+      ;;
+    --clear-brew-cache)
+      CLEAR_BREW_CACHE=true
+      shift
+      ;;
+    --npm-only)
+      RUN_NPM=true
+      RUN_CARGO=false
+      RUN_BREW=false
+      shift
+      ;;
+    --cargo-only)
+      RUN_NPM=false
+      RUN_CARGO=true
+      RUN_BREW=false
+      shift
+      ;;
+    --work-dir)
+      WORK_DIR="${2:?--work-dir requires a path}"
+      shift 2
+      ;;
+    --keep-work-dir)
+      KEEP_WORK_DIR=true
+      shift
+      ;;
+    --list-matrix)
+      ACTION="list-matrix"
+      shift
+      ;;
+    --self-test)
+      ACTION="self-test"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[ERROR] Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+RUN_DIR="$WORK_DIR/$RUN_LABEL"
+SUMMARY="$RUN_DIR/summary.tsv"
+
+log() {
+  echo "[install-latency] $*"
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "[ERROR] Missing required command: $command_name" >&2
+    return 1
+  fi
+}
+
+duration_ms() {
+  local started_ns="$1"
+  local ended_ns
+  ended_ns="$(date +%s%N)"
+  echo $(((ended_ns - started_ns) / 1000000))
+}
+
+slugify() {
+  echo "$1" | tr '/:@ ' '----' | tr -cd '[:alnum:]_.-'
+}
+
+write_context() {
+  local context_file="$RUN_DIR/context.txt"
+
+  {
+    echo "run_label=$RUN_LABEL"
+    echo "project_root=$PROJECT_ROOT"
+    echo "work_dir=$WORK_DIR"
+    echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "uname=$(uname -a)"
+    echo "os=$(uname -s)"
+    echo "arch=$(uname -m)"
+    if grep -qi microsoft /proc/version 2>/dev/null; then
+      echo "wsl=true"
+      echo "wsl_distro=${WSL_DISTRO_NAME:-unknown}"
+    else
+      echo "wsl=false"
+    fi
+    if command -v node >/dev/null 2>&1; then
+      echo "node=$(node --version)"
+    fi
+    if command -v npm >/dev/null 2>&1; then
+      echo "npm=$(npm --version)"
+    fi
+    if command -v cargo >/dev/null 2>&1; then
+      echo "cargo=$(cargo --version)"
+    fi
+    if command -v rustc >/dev/null 2>&1; then
+      echo "rustc=$(rustc --version)"
+    fi
+    if command -v brew >/dev/null 2>&1; then
+      echo "brew=$(brew --version | head -1)"
+    fi
+  } > "$context_file"
+}
+
+run_case() {
+  local manager="$1"
+  local mode="$2"
+  local name="$3"
+  local command_text="$4"
+  shift 4
+
+  local slug
+  slug="$(slugify "$manager-$mode-$name")"
+  local log_file="$RUN_DIR/$slug.log"
+  local started_ns
+  local exit_code=0
+  local ms
+
+  log "Running [$manager][$mode] $name"
+  started_ns="$(date +%s%N)"
+  set +e
+  "$@" > "$log_file" 2>&1
+  exit_code=$?
+  set -e
+  ms="$(duration_ms "$started_ns")"
+
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "$manager" "$mode" "$name" "$ms" "$exit_code" "$command_text" "$log_file" >> "$SUMMARY"
+
+  if [[ "$exit_code" -ne 0 ]]; then
+    log "[WARNING] $name exited with $exit_code; see $log_file"
+  fi
+}
+
+reset_npm_dirs() {
+  rm -rf "$RUN_DIR/npm-cache" "$RUN_DIR/npm-prefix" "$RUN_DIR/npm-home"
+  mkdir -p "$RUN_DIR/npm-cache" "$RUN_DIR/npm-prefix" "$RUN_DIR/npm-home"
+}
+
+run_npm_matrix() {
+  require_command npm
+  require_command npx
+
+  reset_npm_dirs
+
+  for mode in cold warm; do
+    if [[ "$mode" == "cold" ]]; then
+      reset_npm_dirs
+    fi
+
+    for package_spec in "${NPM_PACKAGES[@]}"; do
+      run_case "npm" "$mode" "npx-$package_spec" "npx --yes $package_spec --version" \
+        env \
+          HOME="$RUN_DIR/npm-home" \
+          npm_config_cache="$RUN_DIR/npm-cache" \
+          npm_config_prefix="$RUN_DIR/npm-prefix" \
+          npm_config_timing=true \
+          npm_config_foreground_scripts=true \
+          npx --yes "$package_spec" --version
+    done
+
+    run_case "npm" "$mode" "npm-install-g-terminal-jarvis" "npm install -g terminal-jarvis" \
+      env \
+        HOME="$RUN_DIR/npm-home" \
+        npm_config_cache="$RUN_DIR/npm-cache" \
+        npm_config_prefix="$RUN_DIR/npm-prefix" \
+        npm_config_timing=true \
+        npm_config_foreground_scripts=true \
+        npm install -g terminal-jarvis
+  done
+}
+
+reset_cargo_dirs() {
+  rm -rf "$RUN_DIR/cargo-home" "$RUN_DIR/cargo-root" "$RUN_DIR/cargo-target"
+  mkdir -p "$RUN_DIR/cargo-home" "$RUN_DIR/cargo-root" "$RUN_DIR/cargo-target"
+}
+
+run_cargo_matrix() {
+  require_command cargo
+
+  reset_cargo_dirs
+
+  for mode in cold warm; do
+    if [[ "$mode" == "cold" ]]; then
+      reset_cargo_dirs
+    fi
+
+    run_case "cargo" "$mode" "cargo-install-terminal-jarvis" "cargo install terminal-jarvis --root <isolated>" \
+      env \
+        CARGO_HOME="$RUN_DIR/cargo-home" \
+        CARGO_TARGET_DIR="$RUN_DIR/cargo-target" \
+        cargo install terminal-jarvis --root "$RUN_DIR/cargo-root" --locked
+  done
+}
+
+run_brew_matrix() {
+  require_command brew
+
+  local formula="ba-calderonmorales/terminal-jarvis/terminal-jarvis"
+  local cache_dir
+  cache_dir="$(brew --cache 2>/dev/null || true)"
+
+  if [[ "$ALLOW_BREW_UNINSTALL" != true ]]; then
+    log "[WARNING] Skipping Homebrew install benchmark because --allow-brew-uninstall was not set"
+    log "[WARNING] Re-run with --include-brew --allow-brew-uninstall when this machine can modify Homebrew state"
+    return 0
+  fi
+
+  for mode in cold warm; do
+    brew uninstall --force terminal-jarvis >/dev/null 2>&1 || true
+
+    if [[ "$mode" == "cold" && "$CLEAR_BREW_CACHE" == true && -n "$cache_dir" ]]; then
+      rm -f "$cache_dir"/downloads/*terminal-jarvis* "$cache_dir"/*terminal-jarvis* 2>/dev/null || true
+    fi
+
+    run_case "homebrew" "$mode" "brew-install-terminal-jarvis" "brew install $formula" \
+      brew install --verbose "$formula"
+  done
+}
+
+summarize_signals() {
+  local signals_file="$RUN_DIR/signals.txt"
+
+  {
+    echo "Install latency diagnostic signals"
+    echo
+    echo "NPM timing logs:"
+    find "$RUN_DIR/npm-cache/_logs" -type f \( -name "*-timing.json" -o -name "*.log" \) -print 2>/dev/null | sort || true
+    echo
+    echo "Postinstall phase markers:"
+    grep -RInE "Detected|Downloading v|Download complete|Extracting|Extraction complete|installed in|Binary installed|Fallback|Error|Warning" "$RUN_DIR"/*.log 2>/dev/null || true
+    echo
+    echo "Homebrew phase markers:"
+    grep -RInE "Downloading|Pouring|Installing|Fetching|Bottle|tar|curl|source|build" "$RUN_DIR"/homebrew-*.log 2>/dev/null || true
+  } > "$signals_file"
+}
+
+main() {
+  cd "$PROJECT_ROOT"
+
+  if [[ "$KEEP_WORK_DIR" != true ]]; then
+    rm -rf "$RUN_DIR"
+  fi
+
+  mkdir -p "$RUN_DIR"
+  printf "manager\tmode\tcase\tduration_ms\texit_code\tcommand\tlog_file\n" > "$SUMMARY"
+  write_context
+
+  if [[ "$RUN_NPM" == true ]]; then
+    run_npm_matrix
+  fi
+
+  if [[ "$RUN_CARGO" == true ]]; then
+    run_cargo_matrix
+  fi
+
+  if [[ "$RUN_BREW" == true ]]; then
+    run_brew_matrix
+  fi
+
+  summarize_signals
+
+  log "Summary: $SUMMARY"
+  log "Context: $RUN_DIR/context.txt"
+  log "Signals: $RUN_DIR/signals.txt"
+}
+
+case "$ACTION" in
+  list-matrix)
+    list_matrix
+    ;;
+  self-test)
+    mkdir -p "$RUN_DIR"
+    self_test
+    ;;
+  run)
+    main "$@"
+    ;;
+  *)
+    echo "[ERROR] Unknown action: $ACTION" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/benchmarks/test-install-latency.sh
+++ b/scripts/benchmarks/test-install-latency.sh
@@ -31,7 +31,10 @@ test_matrix() {
   local output
   output="$("$SCRIPT" --list-matrix)"
   assert_contains "$output" $'npm\tcold\tnpx-terminal-jarvis@beta' "matrix must include beta npx cold benchmark"
+  assert_contains "$output" $'npm\twarm\tnpx-terminal-jarvis' "matrix must include default npx warm benchmark"
+  assert_contains "$output" $'npm\twarm\tnpx-terminal-jarvis@latest' "matrix must include latest npx warm benchmark"
   assert_contains "$output" $'npm\twarm\tnpx-terminal-jarvis@beta' "matrix must include beta npx warm benchmark"
+  assert_contains "$output" $'npm\twarm\tnpx-terminal-jarvis@stable' "matrix must include stable npx warm benchmark"
   assert_contains "$output" $'npm\twarm\tnpm-install-g-terminal-jarvis' "matrix must include warm npm global install"
   assert_contains "$output" $'cargo\tcold\tcargo-install-terminal-jarvis' "matrix must include cargo baseline"
 }

--- a/scripts/benchmarks/test-install-latency.sh
+++ b/scripts/benchmarks/test-install-latency.sh
@@ -31,6 +31,7 @@ test_matrix() {
   local output
   output="$("$SCRIPT" --list-matrix)"
   assert_contains "$output" $'npm\tcold\tnpx-terminal-jarvis@beta' "matrix must include beta npx cold benchmark"
+  assert_contains "$output" $'npm\twarm\tnpx-terminal-jarvis@beta' "matrix must include beta npx warm benchmark"
   assert_contains "$output" $'npm\twarm\tnpm-install-g-terminal-jarvis' "matrix must include warm npm global install"
   assert_contains "$output" $'cargo\tcold\tcargo-install-terminal-jarvis' "matrix must include cargo baseline"
 }
@@ -46,7 +47,8 @@ test_matrix_mutation_is_caught() {
   rm -rf "$mutant_dir"
   mkdir -p "$mutant_dir"
   cp "$SCRIPT" "$mutant"
-  sed -i '/terminal-jarvis@beta/d' "$mutant"
+  awk '$0 != "  \"terminal-jarvis@beta\"" { print }' "$mutant" > "$mutant.tmp"
+  mv "$mutant.tmp" "$mutant"
   chmod +x "$mutant"
 
   if "$mutant" --work-dir "$mutant_dir/work" --self-test >/dev/null 2>&1; then

--- a/scripts/benchmarks/test-install-latency.sh
+++ b/scripts/benchmarks/test-install-latency.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT="$SCRIPT_DIR/install-latency.sh"
+TEST_DIR="$PROJECT_ROOT/tmp/install-latency-tests"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="$3"
+
+  if ! grep -Fq -- "$needle" <<< "$haystack"; then
+    echo "[ERROR] $message" >&2
+    echo "[ERROR] Missing: $needle" >&2
+    exit 1
+  fi
+}
+
+test_help() {
+  local output
+  output="$("$SCRIPT" --help)"
+  assert_contains "$output" "npx --yes terminal-jarvis@stable --version" "help must list stable npx benchmark"
+  assert_contains "$output" "--include-brew" "help must document opt-in Homebrew benchmark"
+  assert_contains "$output" "Recommended latency targets" "help must include latency targets"
+}
+
+test_matrix() {
+  local output
+  output="$("$SCRIPT" --list-matrix)"
+  assert_contains "$output" $'npm\tcold\tnpx-terminal-jarvis@beta' "matrix must include beta npx cold benchmark"
+  assert_contains "$output" $'npm\twarm\tnpm-install-g-terminal-jarvis' "matrix must include warm npm global install"
+  assert_contains "$output" $'cargo\tcold\tcargo-install-terminal-jarvis' "matrix must include cargo baseline"
+}
+
+test_self_test() {
+  "$SCRIPT" --work-dir "$TEST_DIR/self" --self-test >/dev/null
+}
+
+test_matrix_mutation_is_caught() {
+  local mutant_dir="$TEST_DIR/mutant"
+  local mutant="$mutant_dir/install-latency-mutant.sh"
+
+  rm -rf "$mutant_dir"
+  mkdir -p "$mutant_dir"
+  cp "$SCRIPT" "$mutant"
+  sed -i '/terminal-jarvis@beta/d' "$mutant"
+  chmod +x "$mutant"
+
+  if "$mutant" --work-dir "$mutant_dir/work" --self-test >/dev/null 2>&1; then
+    echo "[ERROR] mutation smoke test survived after removing beta benchmark entry" >&2
+    exit 1
+  fi
+}
+
+main() {
+  rm -rf "$TEST_DIR"
+  mkdir -p "$TEST_DIR"
+
+  test_help
+  test_matrix
+  test_self_test
+  test_matrix_mutation_is_caught
+
+  echo "[install-latency-test] all tests passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- adds `scripts/benchmarks/install-latency.sh` for repeatable cold/warm npm/npx, npm global, cargo, and opt-in Homebrew install timing
- captures WSL context, npm timing logs, postinstall phase markers, and recommended latency targets
- fixes npm postinstall redirect handling so GitHub release redirects are drained before following the asset URL
- adds a Vitest unit test for redirect draining plus a shell benchmark self-test with a mutation smoke check

## Initial WSL Ubuntu sample
Run: `scripts/benchmarks/install-latency.sh --npm-only`
Context: WSL2 Ubuntu, Node v22.22.0, npm 10.9.4

Cold npm/npx timings from `tmp/install-latency/20260515T032231Z/summary.tsv`:
- `npx --yes terminal-jarvis --version`: 32.3s
- `npx --yes terminal-jarvis@latest --version`: 31.2s
- `npx --yes terminal-jarvis@beta --version`: 31.1s
- `npx --yes terminal-jarvis@stable --version`: 31.2s
- `npm install -g terminal-jarvis`: 31.0s

Warm npx timings were 0.3s to 0.8s. Warm `npm install -g terminal-jarvis` remained 31.4s.

npm timing logs attributed about 30s to `build:run:postinstall`, while Terminal Jarvis postinstall logged success in 0.7s to 1.0s for most cases. That mismatch led to the redirect-drain fix in `postinstall.js`.

## Validation
- `bash -n scripts/benchmarks/install-latency.sh scripts/benchmarks/test-install-latency.sh`
- `scripts/benchmarks/test-install-latency.sh`
- `npm test` in `npm/terminal-jarvis`
- `npm run typecheck` in `npm/terminal-jarvis`
- `scripts/benchmarks/install-latency.sh --npm-only`

## Notes
- Homebrew timing is opt-in in the script because it changes the real Homebrew prefix.
- `shellcheck` is not installed in this local environment, so it was not run locally.

Closes #110
