### PR TITLE
Harden v0.1 local CD release prep

### DIFF
--- a/.github/workflows/cd-multiplatform.yml
+++ b/.github/workflows/cd-multiplatform.yml
@@ -85,11 +85,19 @@ jobs:
             v*) ;;
             *) echo "release tag must start with v: $tag" >&2; exit 1 ;;
           esac
+          version="${tag#v}"
 
           mkdir -p release-assets
           find artifacts -type f \( -name "terminal-jarvis-*.tar.gz" -o -name "*.sha256" \) \
             -exec cp {} release-assets/ \;
-          test "$(find release-assets -type f | wc -l | tr -d ' ')" -gt 0
+          for platform in linux-x64-gnu macos-x64 macos-arm64; do
+            archive="terminal-jarvis-$version-$platform.tar.gz"
+            test -f "release-assets/$archive"
+            test -f "release-assets/$archive.sha256"
+            expected="$(cut -d ' ' -f 1 "release-assets/$archive.sha256")"
+            actual="$(sha256sum "release-assets/$archive" | cut -d ' ' -f 1)"
+            test "$expected" = "$actual"
+          done
 
           if gh release view "$tag" >/dev/null 2>&1; then
             gh release upload "$tag" release-assets/* --clobber
@@ -97,5 +105,5 @@ jobs:
             gh release create "$tag" release-assets/* \
               --draft \
               --title "$tag" \
-              --notes "Draft v0.1.0 harness catalog release assets."
+              --notes "Draft $tag harness catalog release assets."
           fi

--- a/.github/workflows/cd-multiplatform.yml
+++ b/.github/workflows/cd-multiplatform.yml
@@ -66,6 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - uses: actions/checkout@v7
+
       - uses: actions/download-artifact@v8
         with:
           path: artifacts
@@ -90,12 +92,23 @@ jobs:
           mkdir -p release-assets
           find artifacts -type f \( -name "terminal-jarvis-*.tar.gz" -o -name "*.sha256" \) \
             -exec cp {} release-assets/ \;
-          for platform in linux-x64-gnu macos-x64 macos-arm64; do
+          platforms="$(
+            sed -n 's/^release_platforms = \[\(.*\)\]/\1/p' scripts/release.toml |
+              tr ',' '\n' |
+              tr -d ' "'
+          )"
+          test -n "$platforms"
+          for platform in $platforms; do
             archive="terminal-jarvis-$version-$platform.tar.gz"
             test -f "release-assets/$archive"
             test -f "release-assets/$archive.sha256"
             expected="$(cut -d ' ' -f 1 "release-assets/$archive.sha256")"
+            recorded="$(awk '{print $2}' "release-assets/$archive.sha256")"
             actual="$(sha256sum "release-assets/$archive" | cut -d ' ' -f 1)"
+            case "$recorded" in
+              "$archive" | "./$archive") ;;
+              *) echo "release-assets/$archive.sha256 references $recorded, expected $archive" >&2; exit 1 ;;
+            esac
             test "$expected" = "$actual"
           done
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,15 @@
-# AGENTS.md - Terminal Jarvis Minor Revision
+# AGENTS.md - Terminal Jarvis
 
 ## Current Shape
 
 - `src/` contains the slim Rust CLI for the new harness catalog model.
 - `harnesses/` is the data plane for coding-agent harness capabilities.
-- `docs/` is intentionally present for this breaking minor revision.
-- The pre-rewrite implementation is intentionally pruned from this PR; use Git
-  history for legacy reference.
+- `docs/` is intentionally present for architecture, testing, migration, and
+  release notes.
+- `scripts/local-ci.sh`, `scripts/local-cd.sh`, and
+  `scripts/package-release.sh` are the local release-prep path.
+- The pre-rewrite implementation is intentionally pruned; use Git history for
+  legacy reference.
 
 ## Rules
 
@@ -16,4 +19,9 @@
 - Do not add a second Go ADK or another runtime beside the Rust CLI.
 - Use no external Rust dependencies unless the tradeoff is documented first.
 - Keep docs concise and tied to migration, architecture, testing, or release notes.
-- Do not reintroduce a `current/` snapshot in this PR.
+- Do not reintroduce a `current/` snapshot.
+- Do not tag, publish, or upload release assets from local scripts without an
+  explicit operator decision.
+- Prefer remote or disposable development environments when exercising harness
+  install, update, headless, or yolo commands. Keep secrets scoped and do not
+  run unreviewed agent commands on a daily-driver machine.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Terminal Jarvis is being simplified into a small Rust CLI that switches between
 coding-agent harnesses through data contracts instead of hard-coded tool logic.
 
-This branch is the first breaking minor revision. The old implementation is
-pruned from this PR so review can focus on the lean v0.1 root.
+The v0.1.0 line is a breaking minor revision focused on the harness catalog,
+local release checks, and compact distribution surfaces.
 
 ## Quick Start
 
@@ -16,17 +16,34 @@ cargo run -- use opencode
 cargo run -- current
 ```
 
-Run the branch verification gate with:
+Run the verification gate with:
 
 ```bash
 scripts/verify.sh
 ```
 
-Run the stronger pre-PR gate with local security and package checks:
+Run the stronger local gate with security and package checks:
 
 ```bash
 scripts/local-ci.sh
 ```
+
+Exercise the local release asset shape without tagging or publishing:
+
+```bash
+scripts/local-cd.sh --check-auth
+```
+
+## Development Environment
+
+Prefer a remote or disposable Linux workspace for Terminal Jarvis development:
+Codespaces, a short-lived VM/container, or an SSH development host. Coding-agent
+harnesses install binaries, inspect repositories, and can run delegated commands,
+so avoid testing new harness plans directly on a daily-driver machine.
+
+Keep provider tokens scoped to the work, mount only the repositories being
+tested, and treat `headless`, `install`, `update`, and `yolo` capability plans as
+commands to review before execution.
 
 ## New Layout
 
@@ -64,9 +81,13 @@ without forcing users to configure every provider a tool supports.
 - Aim for 90 percent or better line coverage and mutation score as the CLI
   stabilizes.
 
-## Release Status
+## Release Path
 
-This branch is not ready for packaged release. Cargo is the active development
-surface. Minimal npm and Homebrew source-build surfaces exist for smoke testing
-until versioned release artifacts are rebuilt through
-[docs/release-plan.md](docs/release-plan.md).
+Cargo is the active development surface. Minimal npm and Homebrew source-build
+surfaces are included for smoke testing, while `scripts/package-release.sh`
+builds versioned archives, checksums, npm staging files, and generated Homebrew
+formula output. Tagged releases use `.github/workflows/cd-multiplatform.yml` to
+publish draft GitHub release assets after hosted CI passes.
+
+See [docs/release-plan.md](docs/release-plan.md) for the v0.1.0 checklist and
+auth boundaries.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
-# Terminal Jarvis Minor Revision
+# Terminal Jarvis Docs
 
 This repository now centers on the new Rust harness catalog CLI.
 
-The first minor revision is expected to break old interfaces so the project can
-reduce build time, remove the Go ADK experiment, make package hygiene clearer,
-and increase unit, integration, e2e, coverage, and mutation testing over time.
+The v0.1.0 minor line intentionally breaks old interfaces so the project can
+reduce build time, remove the Go ADK experiment from the active root, make
+package hygiene clearer, and keep release confidence tied to compact checks.
 
 ## Documents
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,13 +1,13 @@
 # Migration
 
-The pre-rewrite implementation is intentionally pruned from this PR.
+The pre-rewrite implementation is intentionally pruned from the active root.
 
 ## Upgrade Path
 
 1. Use Git history as the reference for pre-rewrite behavior.
 2. Keep each promoted harness on the shared capability contract.
 3. Run `scripts/verify.sh` after each promotion.
-4. Use draft PR CI to compare the new root against hosted checks.
+4. Use pull request CI to compare the new root against hosted checks.
 
 The first promotion pass covers 25 initial harnesses. Several capabilities
 intentionally point at `--help` or an explicit unavailable plan until the exact
@@ -17,5 +17,6 @@ harness-specific command is verified.
 
 - The new root no longer exposes the old menu system.
 - The Go ADK is not part of the new root.
-- NPM and e2e wrapper work needs to be rebuilt against the new CLI surface.
-- Release automation needs to be reconnected after the catalog stabilizes.
+- NPM is a minimal source-wrapper surface until release binaries are published.
+- Homebrew is source-build by default until versioned release formulas are
+  promoted with real archive checksums.

--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -53,8 +53,9 @@ labels such as `linux-x64-gnu` or `macos-arm64`; the Rust target triple remains
 visible in `scripts/package-release.sh --check`.
 
 `scripts/local-cd.sh` collects the same archive and checksum files into a
-`release-assets/v<version>/` directory and verifies every checksum. In this
-workspace, its default output is `testing/terminal-jarvis/local-cd/`.
+`release-assets/v<version>/` directory and verifies every checksum and recorded
+archive filename. Release script defaults live in `scripts/release.toml`. In
+this workspace, default output is `testing/terminal-jarvis/local-cd/`.
 
 ## Distribution Hygiene
 

--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -1,6 +1,7 @@
 # Release Plan
 
-This branch is preparing the first breaking minor revision before `v1.0.0`.
+This repository is preparing `v0.1.0`, the first breaking minor revision before
+`v1.0.0`.
 
 ## User Notice
 
@@ -15,7 +16,7 @@ For source users:
 
 ```bash
 git fetch
-git checkout minor/harness-catalog-v0.1
+git checkout develop
 cargo run -- list
 scripts/verify.sh
 ```
@@ -38,30 +39,38 @@ For host release packaging:
 scripts/package-release.sh
 ```
 
-The package script writes ignored artifacts under `dist/<version>/<platform>/`:
+For the full local CD smoke path without tagging, pushing, or publishing:
+
+```bash
+scripts/local-cd.sh --check-auth
+```
+
+The package script writes artifacts under `<out>/<version>/<platform>/`:
 a binary archive with bundled harness data, a SHA-256 file, an npm package
 staging directory with `bin/terminal-jarvis-bin`, and a versioned Homebrew
 formula that points at the release archive URL. Platform names are user-facing
 labels such as `linux-x64-gnu` or `macos-arm64`; the Rust target triple remains
 visible in `scripts/package-release.sh --check`.
 
-For packaged users, keep using the current published release until the new npm,
-Cargo, and Homebrew surfaces are rebuilt around the harness catalog CLI.
+`scripts/local-cd.sh` collects the same archive and checksum files into a
+`release-assets/v<version>/` directory and verifies every checksum. In this
+workspace, its default output is `testing/terminal-jarvis/local-cd/`.
 
 ## Distribution Hygiene
 
 Before publishing this minor revision:
 
 1. Run `scripts/verify.sh`.
-2. Run `cargo llvm-cov` with the 90 percent line coverage gate installed.
-3. Run `TJ_MUTATION=1 scripts/verify.sh` with `cargo-mutants` installed.
-4. Run `cargo audit` and `cargo deny check`.
-5. Run `npm --prefix npm/terminal-jarvis audit --omit=dev --audit-level=moderate`.
-6. Run `scripts/package-release.sh` and publish the generated archive and npm
-   staging package for each supported target.
-7. Review and publish the generated versioned Homebrew Formula with the real
-   SHA-256 checksums.
-8. Test install, update, and version commands through Cargo, npm, and Homebrew.
+2. Run `scripts/local-ci.sh`; pass `--strict` when optional security tools must
+   be installed instead of skipped.
+3. Run `scripts/local-cd.sh --check-auth` and inspect
+   `testing/terminal-jarvis/local-cd/release-assets/v0.1.0/`.
+4. Run `cargo llvm-cov` with the 90 percent line coverage gate installed when
+   coverage is not already covered by `scripts/verify.sh`.
+5. Run `TJ_MUTATION=1 scripts/verify.sh` or `scripts/local-ci.sh --mutation`
+   with `cargo-mutants` installed before cutting the tag.
+6. Test install, update, and version commands through Cargo, npm, and Homebrew.
+7. Push a signed or reviewed `v0.1.0` tag only after the release PR is accepted.
 
 The root GitHub workflows intentionally replace the old release flow. CI now
 verifies the lean Rust crate, catalog contracts, package metadata, security
@@ -69,6 +78,11 @@ gates, npm wrapper, Homebrew syntax, coverage, and mutation. Multi-platform CD
 builds host archives for Linux and macOS and publishes draft GitHub release
 assets for tagged releases.
 
-The old implementation is intentionally pruned from this PR to keep review
-focused on the v0.1 root; use Git history when legacy release behavior needs
-inspection.
+Auth boundaries:
+
+- GitHub draft release upload requires `contents: write` through GitHub Actions
+  or a local `gh` session with equivalent repository access.
+- npm publish still requires a renewed npm automation token with package publish
+  rights before any registry publish step is added or run.
+- crates.io publish requires `CARGO_REGISTRY_TOKEN` with publish scope before
+  any Cargo publish step is added or run.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,6 +40,8 @@ scripts/local-cd.sh --check-auth
 That script delegates package creation to `scripts/package-release.sh`, collects
 the same archive/checksum files that CD uploads, verifies checksums, and reports
 GitHub, npm, and Cargo auth boundaries without printing secrets.
+It also checks that each `.sha256` file names the archive basename so flattened
+release assets work with `sha256sum -c`.
 
 ## Environment Safety
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,7 +1,7 @@
 # Testing
 
 The baseline target is 90 percent or better line coverage and mutation score.
-This branch starts by making behavior smaller and more testable.
+The v0.1.0 root starts by making behavior smaller and more testable.
 
 The current tests enforce the expected 25-harness catalog, the full
 nine-capability harness contract, non-interactive update plans, visible yolo
@@ -19,7 +19,7 @@ npm wrapper smoke checks, Homebrew Formula syntax checks, and coverage/mutation
 gates. It also checks release-package metadata without writing `dist/`
 artifacts.
 
-For the stronger pre-PR gate, run:
+For the stronger local gate, run:
 
 ```bash
 scripts/local-ci.sh
@@ -30,6 +30,24 @@ supply-chain checks, the standard verification gate, and release package smoke
 checks. Missing optional local tools are reported as skips by default; pass
 `--strict` when every configured security tool must be installed and runnable.
 Pass `--mutation` for the slower mutation gate before opening or updating a PR.
+
+For release asset smoke testing, run:
+
+```bash
+scripts/local-cd.sh --check-auth
+```
+
+That script delegates package creation to `scripts/package-release.sh`, collects
+the same archive/checksum files that CD uploads, verifies checksums, and reports
+GitHub, npm, and Cargo auth boundaries without printing secrets.
+
+## Environment Safety
+
+Use a remote or disposable Linux workspace when testing harness installation,
+updates, headless execution, or yolo-style plans. These commands are designed to
+orchestrate coding agents and local binaries, so the safest default is a
+short-lived workspace with only the target repository mounted and only the
+provider tokens needed for that test.
 
 ## Optional Gates
 

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -3,8 +3,8 @@
 This is the source-build Homebrew surface for the harness-catalog rewrite.
 
 It is intentionally `head`-only until stable release archives and checksums are
-available. Release packaging generates versioned formulas under ignored
-`dist/` output.
+available. Release packaging generates versioned formulas under the configured
+package output directory.
 
 Local checks:
 
@@ -12,5 +12,5 @@ Local checks:
 ruby -c homebrew/Formula/terminal-jarvis.rb
 ```
 
-Release work must replace the `head`-only formula with versioned URLs and real
-SHA-256 checksums.
+Run `scripts/local-cd.sh` to generate and verify versioned archive checksums
+before promoting a release formula.

--- a/npm/terminal-jarvis/README.md
+++ b/npm/terminal-jarvis/README.md
@@ -2,7 +2,8 @@
 
 This is the minimal npm surface for the harness-catalog rewrite.
 
-It does not bundle release binaries yet. In this branch it delegates to:
+It can use a bundled release binary when package output provides one. In source
+checkouts it delegates to:
 
 1. `TERMINAL_JARVIS_BIN`
 2. `bin/terminal-jarvis-bin`

--- a/scripts/local-cd.sh
+++ b/scripts/local-cd.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-repo=terminal-jarvis
+config=scripts/release.toml
 out_root=${TJ_LOCAL_CD_OUT:-}
 auth=0
 
@@ -26,6 +26,26 @@ fail() {
 
 version() {
   sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1
+}
+
+package_name() {
+  sed -n 's/^name = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1
+}
+
+config_value() {
+  sed -n "s/^$1 = \"\\([^\"]*\\)\"/\\1/p" "$config" | head -n 1
+}
+
+find_testing_root() {
+  dir=$PWD
+  while [ "$dir" != "/" ]; do
+    if [ -d "$dir/testing" ]; then
+      echo "$dir/testing"
+      return 0
+    fi
+    dir=$(dirname "$dir")
+  done
+  return 1
 }
 
 sha256_file() {
@@ -70,11 +90,17 @@ done
 
 cd "$(dirname "$0")/.."
 
+name=$(package_name)
+test -n "$name" || fail "Cargo.toml name missing"
+test -f "$config" || fail "$config missing"
+
 if [ -z "$out_root" ]; then
-  if [ -d ../../../testing ]; then
-    out_root=../../../testing/$repo/local-cd
+  local_dir=$(config_value local_cd_dir)
+  test -n "$local_dir" || fail "$config missing local_cd_dir"
+  if testing_root=$(find_testing_root); then
+    out_root=$testing_root/$name/$local_dir
   else
-    out_root=dist/local-cd
+    out_root=dist/$local_dir
   fi
 fi
 
@@ -88,20 +114,26 @@ asset_dir=$out_root/release-assets/$tag
 rm -rf "$asset_dir"
 mkdir -p "$asset_dir"
 find "$out_root/$version" -type f \( \
-  -name "$repo-$version-*.tar.gz" -o \
-  -name "$repo-$version-*.tar.gz.sha256" \
+  -name "$name-$version-*.tar.gz" -o \
+  -name "$name-$version-*.tar.gz.sha256" \
 \) -exec cp {} "$asset_dir/" \;
 
-archives=$(find "$asset_dir" -maxdepth 1 -name "$repo-$version-*.tar.gz" | wc -l | tr -d ' ')
-checksums=$(find "$asset_dir" -maxdepth 1 -name "$repo-$version-*.tar.gz.sha256" | wc -l | tr -d ' ')
+archives=$(find "$asset_dir" -maxdepth 1 -name "$name-$version-*.tar.gz" | wc -l | tr -d ' ')
+checksums=$(find "$asset_dir" -maxdepth 1 -name "$name-$version-*.tar.gz.sha256" | wc -l | tr -d ' ')
 test "$archives" -gt 0 || fail "no release archives collected"
 test "$archives" = "$checksums" || fail "$archives archives but $checksums checksums"
 
-for archive in "$asset_dir"/$repo-$version-*.tar.gz; do
+for archive in "$asset_dir"/$name-$version-*.tar.gz; do
   checksum=$archive.sha256
+  archive_name=$(basename "$archive")
   expected=$(cut -d ' ' -f 1 "$checksum")
+  recorded=$(awk '{print $2}' "$checksum")
   actual=$(sha256_file "$archive" | cut -d ' ' -f 1)
-  test "$expected" = "$actual" || fail "checksum mismatch for $(basename "$archive")"
+  case "$recorded" in
+    "$archive_name" | "./$archive_name") ;;
+    *) fail "$checksum references $recorded, expected $archive_name" ;;
+  esac
+  test "$expected" = "$actual" || fail "checksum mismatch for $archive_name"
 done
 
 if [ "$auth" = "1" ]; then

--- a/scripts/local-cd.sh
+++ b/scripts/local-cd.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env sh
+set -eu
+
+repo=terminal-jarvis
+out_root=${TJ_LOCAL_CD_OUT:-}
+auth=0
+
+usage() {
+  cat <<'EOF'
+usage: scripts/local-cd.sh [--out-dir PATH] [--check-auth]
+
+Builds the local release package shape without tagging, pushing, or publishing.
+Artifacts default to the workspace testing/ area when this checkout is there.
+
+Options:
+  --out-dir PATH  Write package and release-assets output under PATH.
+  --check-auth    Report GitHub, npm, and Cargo auth boundaries without secrets.
+  -h, --help      Show this help.
+EOF
+}
+
+fail() {
+  echo "local-cd: $*" >&2
+  exit 1
+}
+
+version() {
+  sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1"
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1"
+  else
+    fail "sha256sum or shasum is required"
+  fi
+}
+
+check_auth() {
+  if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    echo "github auth: ok for draft release checks"
+  else
+    echo "auth boundary: renew GitHub auth with repo contents write before release upload"
+  fi
+
+  if command -v npm >/dev/null 2>&1 && npm whoami >/dev/null 2>&1; then
+    echo "npm auth: ok for registry identity"
+  else
+    echo "auth boundary: renew npm automation token with package publish rights"
+  fi
+
+  if test -n "${CARGO_REGISTRY_TOKEN:-}"; then
+    echo "cargo auth: CARGO_REGISTRY_TOKEN is present"
+  else
+    echo "auth boundary: set CARGO_REGISTRY_TOKEN with crates.io publish scope"
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --out-dir) out_root=${2:?missing path}; shift ;;
+    --check-auth) auth=1 ;;
+    -h | --help) usage; exit 0 ;;
+    *) echo "local-cd: unknown option $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+cd "$(dirname "$0")/.."
+
+if [ -z "$out_root" ]; then
+  if [ -d ../../../testing ]; then
+    out_root=../../../testing/$repo/local-cd
+  else
+    out_root=dist/local-cd
+  fi
+fi
+
+version=$(version)
+test -n "$version" || fail "Cargo.toml version missing"
+tag=v$version
+
+scripts/package-release.sh build "$out_root"
+
+asset_dir=$out_root/release-assets/$tag
+rm -rf "$asset_dir"
+mkdir -p "$asset_dir"
+find "$out_root/$version" -type f \( \
+  -name "$repo-$version-*.tar.gz" -o \
+  -name "$repo-$version-*.tar.gz.sha256" \
+\) -exec cp {} "$asset_dir/" \;
+
+archives=$(find "$asset_dir" -maxdepth 1 -name "$repo-$version-*.tar.gz" | wc -l | tr -d ' ')
+checksums=$(find "$asset_dir" -maxdepth 1 -name "$repo-$version-*.tar.gz.sha256" | wc -l | tr -d ' ')
+test "$archives" -gt 0 || fail "no release archives collected"
+test "$archives" = "$checksums" || fail "$archives archives but $checksums checksums"
+
+for archive in "$asset_dir"/$repo-$version-*.tar.gz; do
+  checksum=$archive.sha256
+  expected=$(cut -d ' ' -f 1 "$checksum")
+  actual=$(sha256_file "$archive" | cut -d ' ' -f 1)
+  test "$expected" = "$actual" || fail "checksum mismatch for $(basename "$archive")"
+done
+
+if [ "$auth" = "1" ]; then
+  check_auth
+fi
+
+echo "local-cd: assets ready in $asset_dir"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env sh
 set -eu
 
-name=terminal-jarvis
-repo=https://github.com/BA-CalderonMorales/terminal-jarvis
 mode=${1:-build}
 out_root=${2:-dist}
 
@@ -25,6 +23,8 @@ sha256_file() {
   fi
 }
 
+name=$(value_from_cargo name)
+repo=$(value_from_cargo repository)
 version=$(value_from_cargo version)
 target=$(rustc -vV | sed -n 's/^host: //p')
 platform=$(case "$target" in
@@ -38,6 +38,8 @@ platform=$(case "$target" in
 esac)
 archive=$name-$version-$platform.tar.gz
 
+test -n "$name" || fail "Cargo.toml name missing"
+test -n "$repo" || fail "Cargo.toml repository missing"
 test -n "$version" || fail "Cargo.toml version missing"
 test -n "$target" || fail "rustc host target missing"
 test -d harnesses || fail "harnesses directory missing"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -73,7 +73,7 @@ cp -R harnesses "$stage/"
 chmod +x "$stage/bin/$name"
 
 (cd "$dist/package" && tar -czf "../$archive" "$name-$version-$platform")
-sha256_file "$dist/$archive" >"$dist/$archive.sha256"
+(cd "$dist" && sha256_file "$archive" >"$archive.sha256")
 sha=$(cut -d ' ' -f 1 "$dist/$archive.sha256")
 
 cp npm/terminal-jarvis/package.json npm/terminal-jarvis/README.md "$npm_stage/"

--- a/scripts/release.toml
+++ b/scripts/release.toml
@@ -1,0 +1,2 @@
+local_cd_dir = "local-cd"
+release_platforms = ["linux-x64-gnu", "macos-x64", "macos-arm64"]


### PR DESCRIPTION
## Summary

This PR adds the missing local CD smoke path and tightens the v0.1.0 release-prep docs after #122 landed on `develop`.

- Adds `scripts/local-cd.sh` to build the package flow locally without tagging, pushing, or publishing.
- Makes release checksum files portable after CD flattens uploaded assets and validates expected release asset names in `cd-multiplatform.yml`.
- Refreshes root README, AGENTS.md, release/testing docs, npm wrapper notes, and Homebrew notes for the harness-catalog release path.
- Adds root README guidance to prefer remote or disposable Linux development environments when working with Terminal Jarvis harnesses, because coding-agent commands can install binaries and run delegated commands.

## Validation

- `scripts/local-ci.sh` passed.
- `scripts/local-cd.sh --check-auth` passed and wrote assets under `testing/terminal-jarvis/local-cd/release-assets/v0.1.0`.
- `sha256sum -c terminal-jarvis-0.1.0-linux-x64-gnu.tar.gz.sha256` passed for the local release asset.
- Generated Homebrew formula parsed with Ruby.
- Staged npm wrapper listed harnesses from the packaged binary.

## Auth Boundaries

- GitHub auth is available for draft release checks.
- npm publish still needs a renewed npm automation token with package publish rights.
- Cargo publish still needs `CARGO_REGISTRY_TOKEN` with crates.io publish scope.