### PR TITLE
[codex] Restore v0.1 npm channel workflows

### DIFF
--- a/.github/workflows/cd-multiplatform.yml
+++ b/.github/workflows/cd-multiplatform.yml
@@ -18,18 +18,18 @@ env:
 
 jobs:
   package:
-    name: Package - ${{ matrix.label }}
+    name: Package - ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
-          - label: linux-x64
+          - platform: linux-x64-gnu
             os: ubuntu-latest
-          - label: macos-x64
+          - platform: macos-x64
             os: macos-15-intel
-          - label: macos-arm64
+          - platform: macos-arm64
             os: macos-15
     steps:
       - uses: actions/checkout@v7
@@ -54,9 +54,18 @@ jobs:
       - name: Build package
         run: scripts/package-release.sh
 
+      - name: Verify platform package shape
+        run: |
+          set -eu
+          version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)"
+          archive="dist/$version/${{ matrix.platform }}/terminal-jarvis-$version-${{ matrix.platform }}.tar.gz"
+          test -f "$archive"
+          test -f "$archive.sha256"
+          test -f "dist/$version/${{ matrix.platform }}/homebrew/Formula/terminal-jarvis.rb"
+
       - uses: actions/upload-artifact@v7
         with:
-          name: release-${{ matrix.label }}
+          name: release-${{ matrix.platform }}
           path: dist/**
           retention-days: 7
 

--- a/.github/workflows/cd-npm-beta-release.yml
+++ b/.github/workflows/cd-npm-beta-release.yml
@@ -1,0 +1,99 @@
+name: NPM Beta Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish or tag as beta, such as 0.1.0"
+        required: true
+        default: "0.1.0"
+        type: string
+      dry_run:
+        description: "Build and validate without publishing or retagging"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  npm-beta:
+    name: Publish or Tag Beta
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+          cache-dependency-path: npm/terminal-jarvis/package-lock.json
+
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+            target
+          key: cargo-npm-beta-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-v1
+          restore-keys: cargo-npm-beta-${{ runner.os }}-
+
+      - name: Build npm package stage
+        run: scripts/package-release.sh build dist/npm-release
+
+      - name: Publish or retag beta
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          DIST_TAG: beta
+        run: |
+          set -eu
+          if ! [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "invalid version: $INPUT_VERSION" >&2
+            exit 1
+          fi
+          cargo_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)"
+          test "$INPUT_VERSION" = "$cargo_version"
+          package_dir="dist/npm-release/$INPUT_VERSION/linux-x64-gnu/npm/terminal-jarvis"
+          test -f "$package_dir/package.json"
+          test -x "$package_dir/bin/terminal-jarvis"
+          test -x "$package_dir/bin/terminal-jarvis-bin"
+          expected="$(find harnesses -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+          actual="$(node "$package_dir/bin/terminal-jarvis" list | wc -l | tr -d ' ')"
+          test "$actual" = "$expected"
+
+          if npm view "terminal-jarvis@$INPUT_VERSION" version >/dev/null 2>&1; then
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "dry run: npm dist-tag add terminal-jarvis@$INPUT_VERSION $DIST_TAG"
+            else
+              test -n "${NODE_AUTH_TOKEN:-}" || {
+                echo "NPM_TOKEN is required to update npm dist-tags" >&2
+                exit 1
+              }
+              npm dist-tag add "terminal-jarvis@$INPUT_VERSION" "$DIST_TAG"
+            fi
+          elif [ "$DRY_RUN" = "true" ]; then
+            (cd "$package_dir" && npm publish --dry-run --tag "$DIST_TAG")
+          else
+            test -n "${NODE_AUTH_TOKEN:-}" || {
+              echo "NPM_TOKEN is required to publish terminal-jarvis" >&2
+              exit 1
+            }
+            (cd "$package_dir" && npm publish --tag "$DIST_TAG")
+          fi
+
+      - name: Verify beta tag
+        if: ${{ inputs.dry_run == false }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -eu
+          npm view "terminal-jarvis@$INPUT_VERSION" version
+          npm dist-tag ls terminal-jarvis | grep "^beta: $INPUT_VERSION$"

--- a/.github/workflows/cd-npm-stable-release.yml
+++ b/.github/workflows/cd-npm-stable-release.yml
@@ -1,0 +1,99 @@
+name: NPM Stable Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish or tag as stable, such as 0.1.0"
+        required: true
+        default: "0.1.0"
+        type: string
+      dry_run:
+        description: "Build and validate without publishing or retagging"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  npm-stable:
+    name: Publish or Tag Stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+          cache-dependency-path: npm/terminal-jarvis/package-lock.json
+
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+            target
+          key: cargo-npm-stable-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-v1
+          restore-keys: cargo-npm-stable-${{ runner.os }}-
+
+      - name: Build npm package stage
+        run: scripts/package-release.sh build dist/npm-release
+
+      - name: Publish or retag stable
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          DIST_TAG: stable
+        run: |
+          set -eu
+          if ! [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "invalid version: $INPUT_VERSION" >&2
+            exit 1
+          fi
+          cargo_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)"
+          test "$INPUT_VERSION" = "$cargo_version"
+          package_dir="dist/npm-release/$INPUT_VERSION/linux-x64-gnu/npm/terminal-jarvis"
+          test -f "$package_dir/package.json"
+          test -x "$package_dir/bin/terminal-jarvis"
+          test -x "$package_dir/bin/terminal-jarvis-bin"
+          expected="$(find harnesses -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+          actual="$(node "$package_dir/bin/terminal-jarvis" list | wc -l | tr -d ' ')"
+          test "$actual" = "$expected"
+
+          if npm view "terminal-jarvis@$INPUT_VERSION" version >/dev/null 2>&1; then
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "dry run: npm dist-tag add terminal-jarvis@$INPUT_VERSION $DIST_TAG"
+            else
+              test -n "${NODE_AUTH_TOKEN:-}" || {
+                echo "NPM_TOKEN is required to update npm dist-tags" >&2
+                exit 1
+              }
+              npm dist-tag add "terminal-jarvis@$INPUT_VERSION" "$DIST_TAG"
+            fi
+          elif [ "$DRY_RUN" = "true" ]; then
+            (cd "$package_dir" && npm publish --dry-run --tag "$DIST_TAG")
+          else
+            test -n "${NODE_AUTH_TOKEN:-}" || {
+              echo "NPM_TOKEN is required to publish terminal-jarvis" >&2
+              exit 1
+            }
+            (cd "$package_dir" && npm publish --tag "$DIST_TAG")
+          fi
+
+      - name: Verify stable tag
+        if: ${{ inputs.dry_run == false }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -eu
+          npm view "terminal-jarvis@$INPUT_VERSION" version
+          npm dist-tag ls terminal-jarvis | grep "^stable: $INPUT_VERSION$"

--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -83,7 +83,8 @@ Auth boundaries:
 
 - GitHub draft release upload requires `contents: write` through GitHub Actions
   or a local `gh` session with equivalent repository access.
-- npm publish still requires a renewed npm automation token with package publish
-  rights before any registry publish step is added or run.
+- npm beta and stable workflows build the staged npm package through
+  `scripts/package-release.sh`; real publishes or dist-tag updates require a
+  renewed npm automation token with package publish rights in `NPM_TOKEN`.
 - crates.io publish requires `CARGO_REGISTRY_TOKEN` with publish scope before
   any Cargo publish step is added or run.


### PR DESCRIPTION
## Summary

Restores lean npm beta and stable release workflows for the v0.1.0 package surface.

- Adds beta and stable workflow_dispatch paths that build the staged npm package through `scripts/package-release.sh`.
- Supports either publishing an unpublished version with the requested dist-tag or retagging an already-published version.
- Keeps real npm writes behind `dry_run: false` and `NPM_TOKEN`.
- Aligns the multi-platform CD matrix artifact labels with `scripts/release.toml` and validates each platform package shape before artifact upload.
- Updates release-plan auth notes for the restored npm workflows.

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p) }' .github/workflows/*.yml`
- `scripts/local-ci.sh`
- `scripts/local-cd.sh --check-auth`
- `sha256sum -c terminal-jarvis-0.1.0-linux-x64-gnu.tar.gz.sha256`
- `ruby -c testing/terminal-jarvis/local-cd/0.1.0/linux-x64-gnu/homebrew/Formula/terminal-jarvis.rb`
- `node testing/terminal-jarvis/local-cd/0.1.0/linux-x64-gnu/npm/terminal-jarvis/bin/terminal-jarvis list`
- `npm pack --dry-run --loglevel error` in the staged npm package

## Auth Boundaries

- GitHub auth is available for draft release checks.
- Real npm publish/tag updates still require `NPM_TOKEN` with package publish rights.
- Cargo publish still requires `CARGO_REGISTRY_TOKEN` with crates.io publish scope.