### PR TITLE
[codex] Fix release package script on macOS sh

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -27,15 +27,15 @@ name=$(value_from_cargo name)
 repo=$(value_from_cargo repository)
 version=$(value_from_cargo version)
 target=$(rustc -vV | sed -n 's/^host: //p')
-platform=$(case "$target" in
-  x86_64-unknown-linux-gnu) echo linux-x64-gnu ;;
-  aarch64-unknown-linux-gnu) echo linux-arm64-gnu ;;
-  x86_64-unknown-linux-musl) echo linux-x64-musl ;;
-  aarch64-unknown-linux-musl) echo linux-arm64-musl ;;
-  x86_64-apple-darwin) echo macos-x64 ;;
-  aarch64-apple-darwin) echo macos-arm64 ;;
-  *) echo "$target" ;;
-esac)
+case "$target" in
+  x86_64-unknown-linux-gnu) platform=linux-x64-gnu ;;
+  aarch64-unknown-linux-gnu) platform=linux-arm64-gnu ;;
+  x86_64-unknown-linux-musl) platform=linux-x64-musl ;;
+  aarch64-unknown-linux-musl) platform=linux-arm64-musl ;;
+  x86_64-apple-darwin) platform=macos-x64 ;;
+  aarch64-apple-darwin) platform=macos-arm64 ;;
+  *) platform=$target ;;
+esac
 archive=$name-$version-$platform.tar.gz
 
 test -n "$name" || fail "Cargo.toml name missing"


### PR DESCRIPTION
## Summary

Fixes the v0.1.0 tag workflow failure in the macOS package jobs.

- Replaces the command-substitution `case` expression in `scripts/package-release.sh` with a plain POSIX `case` assignment.
- Keeps the existing platform names and artifact shape unchanged.
- Follows the previous release tooling pattern of explicit shell branching instead of relying on less-portable shell parsing.

## Root Cause

The tag-triggered Multi-Platform CD run `28217606956` failed in both macOS package jobs with:

`./scripts/package-release.sh: line 31: syntax error near unexpected token ';;'`

Linux passed because its shell accepted the command-substitution `case` form; macOS `/bin/sh` did not.

## Validation

- `sh -n scripts/package-release.sh`
- `bash -n scripts/package-release.sh`
- `scripts/package-release.sh --check`
- `scripts/package-release.sh`