### PR TITLE
Hotfix v0.1.0 release shell portability

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -27,15 +27,15 @@ name=$(value_from_cargo name)
 repo=$(value_from_cargo repository)
 version=$(value_from_cargo version)
 target=$(rustc -vV | sed -n 's/^host: //p')
-platform=$(case "$target" in
-  x86_64-unknown-linux-gnu) echo linux-x64-gnu ;;
-  aarch64-unknown-linux-gnu) echo linux-arm64-gnu ;;
-  x86_64-unknown-linux-musl) echo linux-x64-musl ;;
-  aarch64-unknown-linux-musl) echo linux-arm64-musl ;;
-  x86_64-apple-darwin) echo macos-x64 ;;
-  aarch64-apple-darwin) echo macos-arm64 ;;
-  *) echo "$target" ;;
-esac)
+case "$target" in
+  x86_64-unknown-linux-gnu) platform=linux-x64-gnu ;;
+  aarch64-unknown-linux-gnu) platform=linux-arm64-gnu ;;
+  x86_64-unknown-linux-musl) platform=linux-x64-musl ;;
+  aarch64-unknown-linux-musl) platform=linux-arm64-musl ;;
+  x86_64-apple-darwin) platform=macos-x64 ;;
+  aarch64-apple-darwin) platform=macos-arm64 ;;
+  *) platform=$target ;;
+esac
 archive=$name-$version-$platform.tar.gz
 
 test -n "$name" || fail "Cargo.toml name missing"


### PR DESCRIPTION
## Summary

Carries the release shell portability hotfix from `develop` into `main` for the v0.1.0 tag workflow.

- Includes PR #126 / commit `e7ba499`, which fixes `scripts/package-release.sh` on macOS `/bin/sh`.
- Keeps the existing release artifact shape and platform names unchanged.

## Root Cause

The tag-triggered Multi-Platform CD run for `v0.1.0` failed in both macOS package jobs because macOS `/bin/sh` rejected the command-substitution `case` form in `scripts/package-release.sh`.

## Validation

- PR #126 hosted `Verify`, `Package Smoke`, and `Mutation` checks passed.
- Local focused checks: `sh -n`, `bash -n`, `scripts/package-release.sh --check`, `scripts/package-release.sh`.