### PR TITLE
[codex] Fix npm release artifact permissions

### DIFF
--- a/.github/workflows/cd-multiplatform.yml
+++ b/.github/workflows/cd-multiplatform.yml
@@ -305,6 +305,7 @@ jobs:
           }
           package_dir="artifacts/$VERSION/linux-x64-gnu/npm/terminal-jarvis"
           test -f "$package_dir/package.json"
+          chmod +x "$package_dir/bin/terminal-jarvis" "$package_dir/bin/terminal-jarvis-bin"
           test -x "$package_dir/bin/terminal-jarvis"
           test -x "$package_dir/bin/terminal-jarvis-bin"
           (cd "$package_dir" && npm pack --dry-run --loglevel error)


### PR DESCRIPTION
## Summary

Fix the final npm stage in the restored tag-driven CD workflow.

Actions artifact download can strip executable bits, so the npm publish job now restores execute permission on the staged wrapper and binary before checking them and running `npm pack` / publish or retag.

## Context

The restored `v0.1.0` CD run passed:

- release metadata
- all three platform package jobs
- crates.io publish/verify
- GitHub release publish
- Homebrew tap update

It failed in the final npm job before `npm pack`, consistent with the downloaded artifact permission check.

## Validation

- YAML parse for `cd-multiplatform.yml`
- extracted workflow `run` blocks through `bash -n`
- local chmod simulation on the downloaded `release-linux-x64-gnu` artifact
- `npm pack --dry-run --loglevel error` in the downloaded Linux npm package stage