### PR TITLE
Release npm artifact permission fix

### DIFF
--- a/.github/workflows/cd-multiplatform.yml
+++ b/.github/workflows/cd-multiplatform.yml
@@ -305,6 +305,7 @@ jobs:
           }
           package_dir="artifacts/$VERSION/linux-x64-gnu/npm/terminal-jarvis"
           test -f "$package_dir/package.json"
+          chmod +x "$package_dir/bin/terminal-jarvis" "$package_dir/bin/terminal-jarvis-bin"
           test -x "$package_dir/bin/terminal-jarvis"
           test -x "$package_dir/bin/terminal-jarvis-bin"
           (cd "$package_dir" && npm pack --dry-run --loglevel error)


### PR DESCRIPTION
## Summary

Carry the npm artifact permission fix from `develop` to `main`.

The restored tag-driven CD flow made it through package, crates.io, GitHub release, and Homebrew tap, then failed in the final npm job before `npm pack`. The Linux npm artifact path was correct; the job needed to restore executable bits after artifact download before checking the wrapper and binary.

## Validation

PR #130 into `develop` passed hosted checks:

- Verify
- Package Smoke
- Mutation

Local validation included YAML parsing, extracted workflow shell parsing, chmod simulation on the downloaded `release-linux-x64-gnu` artifact, and `npm pack --dry-run --loglevel error` from that package stage.