### PR TITLE
Patch release 0.1.1 for npm README

### DIFF
--- a/.github/workflows/cd-multiplatform.yml
+++ b/.github/workflows/cd-multiplatform.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release tag to publish, such as v0.1.0"
+        description: "Release tag to publish, such as v0.1.1"
         required: true
         type: string
 

--- a/.github/workflows/cd-npm-beta-release.yml
+++ b/.github/workflows/cd-npm-beta-release.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to publish or tag as beta, such as 0.1.0"
+        description: "Version to publish or tag as beta, such as 0.1.1"
         required: true
-        default: "0.1.0"
+        default: "0.1.1"
         type: string
       dry_run:
         description: "Build and validate without publishing or retagging"

--- a/.github/workflows/cd-npm-release-recovery.yml
+++ b/.github/workflows/cd-npm-release-recovery.yml
@@ -1,13 +1,21 @@
-name: NPM Stable Release
+name: NPM Release Recovery
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to publish or tag as stable, such as 0.1.1"
+        description: "Version to publish or retag, such as 0.1.1 or v0.1.1"
         required: true
-        default: "0.1.1"
         type: string
+      dist_tag:
+        description: "NPM dist-tag to publish or move"
+        required: true
+        default: latest
+        type: choice
+        options:
+          - latest
+          - stable
+          - beta
       dry_run:
         description: "Build and validate without publishing or retagging"
         required: true
@@ -18,12 +26,28 @@ permissions:
   contents: read
 
 jobs:
-  npm-stable:
-    name: Publish or Tag Stable
+  npm-recovery:
+    name: Publish or Retag NPM
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Normalize version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ inputs.version }}"
+          version="${version#v}"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "version must be X.Y.Z or vX.Y.Z: ${{ inputs.version }}" >&2
+            exit 1
+          }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.version.outputs.tag }}
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -40,43 +64,38 @@ jobs:
             ~/.cargo/git
             ~/.cargo/registry
             target
-          key: cargo-npm-stable-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-v1
-          restore-keys: cargo-npm-stable-${{ runner.os }}-
+          key: cargo-npm-recovery-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-v1
+          restore-keys: cargo-npm-recovery-${{ runner.os }}-
 
       - name: Build npm package stage
         run: scripts/package-release.sh build dist/npm-release
 
-      - name: Publish or retag stable
+      - name: Publish or retag package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          INPUT_VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
+          DIST_TAG: ${{ inputs.dist_tag }}
           DRY_RUN: ${{ inputs.dry_run }}
-          DIST_TAG: stable
         run: |
           set -eu
-          if ! [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "invalid version: $INPUT_VERSION" >&2
-            exit 1
-          fi
           cargo_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)"
-          test "$INPUT_VERSION" = "$cargo_version"
-          package_dir="dist/npm-release/$INPUT_VERSION/linux-x64-gnu/npm/terminal-jarvis"
+          test "$VERSION" = "$cargo_version"
+          package_dir="dist/npm-release/$VERSION/linux-x64-gnu/npm/terminal-jarvis"
           test -f "$package_dir/package.json"
+          chmod +x "$package_dir/bin/terminal-jarvis" "$package_dir/bin/terminal-jarvis-bin"
           test -x "$package_dir/bin/terminal-jarvis"
           test -x "$package_dir/bin/terminal-jarvis-bin"
-          expected="$(find harnesses -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
-          actual="$(node "$package_dir/bin/terminal-jarvis" list | wc -l | tr -d ' ')"
-          test "$actual" = "$expected"
+          (cd "$package_dir" && npm pack --dry-run --loglevel error)
 
-          if npm view "terminal-jarvis@$INPUT_VERSION" version >/dev/null 2>&1; then
+          if npm view "terminal-jarvis@$VERSION" version >/dev/null 2>&1; then
             if [ "$DRY_RUN" = "true" ]; then
-              echo "dry run: npm dist-tag add terminal-jarvis@$INPUT_VERSION $DIST_TAG"
+              echo "dry run: npm dist-tag add terminal-jarvis@$VERSION $DIST_TAG"
             else
               test -n "${NODE_AUTH_TOKEN:-}" || {
                 echo "NPM_TOKEN is required to update npm dist-tags" >&2
                 exit 1
               }
-              npm dist-tag add "terminal-jarvis@$INPUT_VERSION" "$DIST_TAG"
+              npm dist-tag add "terminal-jarvis@$VERSION" "$DIST_TAG"
             fi
           elif [ "$DRY_RUN" = "true" ]; then
             (cd "$package_dir" && npm publish --dry-run --tag "$DIST_TAG")
@@ -88,12 +107,12 @@ jobs:
             (cd "$package_dir" && npm publish --tag "$DIST_TAG")
           fi
 
-      - name: Verify stable tag
+      - name: Verify dist-tag
         if: ${{ inputs.dry_run == false }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          INPUT_VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
+          DIST_TAG: ${{ inputs.dist_tag }}
         run: |
           set -eu
-          npm view "terminal-jarvis@$INPUT_VERSION" version
-          npm dist-tag ls terminal-jarvis | grep "^stable: $INPUT_VERSION$"
+          npm view "terminal-jarvis@$VERSION" version
+          npm dist-tag ls terminal-jarvis | grep "^$DIST_TAG: $VERSION$"

--- a/.github/workflows/cd-npm-release-recovery.yml
+++ b/.github/workflows/cd-npm-release-recovery.yml
@@ -23,6 +23,7 @@ on:
         type: boolean
 
 permissions:
+  actions: write
   contents: read
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## [0.1.0] - Unreleased
+## [0.1.1] - 2026-06-26
+
+- Publishes the npm package with the repository root README.
+- Keeps the tag-driven release workflow on patch increments for release and
+  packaging repairs.
+- Restores the npm release recovery workflow to the current package layout.
+
+## [0.1.0] - 2026-06-26
 
 - Starts the breaking minor revision around a data-driven harness catalog.
 - Prunes the pre-rewrite implementation from the PR to keep review focused on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "terminal-jarvis"
-version = "0.1.0"
+version = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-jarvis"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A data-driven harness switcher for AI coding agents"
 authors = ["BA-CalderonMorales"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Terminal Jarvis is being simplified into a small Rust CLI that switches between
 coding-agent harnesses through data contracts instead of hard-coded tool logic.
 
-The v0.1.0 line is a breaking minor revision focused on the harness catalog,
+The v0.1 line is a breaking minor revision focused on the harness catalog,
 local release checks, and compact distribution surfaces.
 
 ## Quick Start
@@ -89,5 +89,5 @@ builds versioned archives, checksums, npm staging files, and generated Homebrew
 formula output. Tagged releases use `.github/workflows/cd-multiplatform.yml` to
 publish the crate, GitHub release assets, Homebrew tap update, and npm package.
 
-See [docs/release-plan.md](docs/release-plan.md) for the v0.1.0 checklist and
+See [docs/release-plan.md](docs/release-plan.md) for the v0.1 release checklist and
 auth boundaries.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 This repository now centers on the new Rust harness catalog CLI.
 
-The v0.1.0 minor line intentionally breaks old interfaces so the project can
+The v0.1 minor line intentionally breaks old interfaces so the project can
 reduce build time, remove the Go ADK experiment from the active root, make
 package hygiene clearer, and keep release confidence tied to compact checks.
 

--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -1,7 +1,11 @@
 # Release Plan
 
-This repository is preparing `v0.1.0`, the first breaking minor revision before
-`v1.0.0`.
+This repository is on the `v0.1.x` line, the first breaking minor revision
+before `v1.0.0`.
+
+Patch releases carry packaging, release automation, documentation, and bug
+fixes. Do not cut a minor or major version unless that version level is
+explicitly requested.
 
 ## User Notice
 
@@ -59,19 +63,20 @@ this workspace, default output is `testing/terminal-jarvis/local-cd/`.
 
 ## Distribution Hygiene
 
-Before publishing this minor revision:
+Before publishing a `v0.1.x` release:
 
 1. Run `scripts/verify.sh`.
 2. Run `scripts/local-ci.sh`; pass `--strict` when optional security tools must
    be installed instead of skipped.
-3. Run `scripts/local-cd.sh --check-auth` and inspect
-   `testing/terminal-jarvis/local-cd/release-assets/v0.1.0/`.
+3. Run `scripts/local-cd.sh --check-auth` and inspect the generated
+   `testing/terminal-jarvis/local-cd/release-assets/v<version>/` directory.
 4. Run `cargo llvm-cov` with the 90 percent line coverage gate installed when
    coverage is not already covered by `scripts/verify.sh`.
 5. Run `TJ_MUTATION=1 scripts/verify.sh` or `scripts/local-ci.sh --mutation`
    with `cargo-mutants` installed before cutting the tag.
 6. Test install, update, and version commands through Cargo, npm, and Homebrew.
-7. Push a signed or reviewed `v0.1.0` tag only after the release PR is accepted.
+7. Push a signed or reviewed `v<version>` tag only after the release PR is
+   accepted.
 
 The root GitHub workflows keep the tag-push release shape. CI verifies the lean
 Rust crate, catalog contracts, package metadata, security gates, npm wrapper,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,7 +1,7 @@
 # Testing
 
 The baseline target is 90 percent or better line coverage and mutation score.
-The v0.1.0 root starts by making behavior smaller and more testable.
+The v0.1 root starts by making behavior smaller and more testable.
 
 The current tests enforce the expected 25-harness catalog, the full
 nine-capability harness contract, non-interactive update plans, visible yolo

--- a/npm/terminal-jarvis/package-lock.json
+++ b/npm/terminal-jarvis/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terminal-jarvis",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "bin": {
         "terminal-jarvis": "bin/terminal-jarvis"

--- a/npm/terminal-jarvis/package.json
+++ b/npm/terminal-jarvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Data-driven harness switcher for AI coding agents",
   "bin": {
     "terminal-jarvis": "bin/terminal-jarvis"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -78,7 +78,8 @@ chmod +x "$stage/bin/$name"
 (cd "$dist" && sha256_file "$archive" >"$archive.sha256")
 sha=$(cut -d ' ' -f 1 "$dist/$archive.sha256")
 
-cp npm/terminal-jarvis/package.json npm/terminal-jarvis/README.md "$npm_stage/"
+cp npm/terminal-jarvis/package.json "$npm_stage/"
+cp README.md "$npm_stage/"
 cp npm/terminal-jarvis/bin/terminal-jarvis "$npm_stage/bin/"
 cp target/release/$name "$npm_stage/bin/terminal-jarvis-bin"
 cp -R harnesses "$npm_stage/"


### PR DESCRIPTION
## Summary

Carry the `0.1.1` patch release from `develop` to `main`.

This fixes the npm README issue by staging the repository root `README.md` into the npm package. Since npm package tarballs are immutable and `0.1.0` already existed, this uses a patch increment rather than trying to overwrite the published tarball.

It also restores the NPM Release Recovery workflow on the current package layout and keeps release docs aligned with the `v0.1.x` patch policy.

## Validation

PR #132 into `develop` passed hosted checks:

- Verify
- Package Smoke
- Mutation

Local validation included registry availability checks for `0.1.1`, workflow YAML/shell parsing, package staging, npm pack dry-run with root README included, cargo publish dry-run, and `scripts/local-ci.sh`.