### PR TITLE
docs: slim README, extract capability contract, agent list, and maintainer guide into docs/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,9 +24,9 @@
 - **Docs-only PRs** (changes limited to `docs/`, `README.md`, `AGENTS.md`,
   `CLAUDE.md`) skip CI automatically via `paths-ignore`. Trigger manually
   with `workflow_dispatch` when needed.
-- The capability contract tables in `README.md` are the source of truth for
-  the tool command surface and the harness capability set. Keep them in sync
-  when adding capabilities or commands.
+- The harness capability contract lives in
+  [docs/harness-capability-contract.md](docs/harness-capability-contract.md).
+  Keep it in sync when adding capabilities or commands.
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -1,135 +1,87 @@
 # Terminal Jarvis
 
-A data-driven harness switcher for AI coding agents. Terminal Jarvis maps
-**25 coding-agent CLIs** through a shared **9-capability contract** --
-one interface to download, run, update, and inspect any agent tool.
+A data-driven harness switcher for AI coding agents. Maps **25 coding-agent
+CLIs** through a shared **9-capability contract** -- one interface to
+download, run, update, and inspect any agent tool.
 
-## The Pattern
+## Install
 
-Every harness exposes the same capability set. The tool commands are uniform
-across all agents. Differences shrink to the `index.toml` files.
+```bash
+# Cargo
+cargo install terminal-jarvis
 
-### Tool Commands (what Terminal Jarvis does)
+# npm
+npm install -g terminal-jarvis
 
-| Command | Purpose |
-|---|---|
-| `list` | Show all available coding agents |
-| `show <harness>` | Inspect a harness's full capability set |
-| `use <harness>` / `current` | Select / show active harness |
-| `plan [harness] <capability>` | Preview the shell command for a capability |
-| `run [harness] [capability] [args...]` | Execute a capability through the harness |
-| `check` | Report binary and environment readiness |
-| `security [status\|audit\|harness]` | Per-harness security posture |
-| `version [--verbose]` / `--version` / `-v` / `--info` | Version and provenance info |
-| `config show` | Active configuration state |
-| `auth help <harness>` | Credential setup guidance |
-| `[harness] [args...]` | Direct pass-through to the harness binary |
-
-Legacy aliases: `tools` &rarr; `list`, `status` &rarr; `check`, `info` &rarr; `show`,
-`install` &rarr; `run <h> download`, `update` &rarr; `run <h> update`.
-
-### Harness Capability Contract (every agent, every time)
-
-| Capability | Safety | Behavior |
-|---|---|---|
-| `download` | safe | Install the agent without sudo |
-| `update` | safe | Upgrade without interactive auth |
-| `headless` | safe | Run in non-interactive / command mode |
-| `version` | safe | Print the installed agent version |
-| `stats` | safe | Show local agent statistics |
-| `models` | safe | List available models |
-| `security` | safe | Review sandbox and approval settings |
-| `ui` | safe | Open the interactive terminal UI |
-| `yolo` | **dangerous** | Bypass all safeguards and approvals |
-
-8 safe capabilities, 1 dangerous. Every one of the **25 harnesses** implements
-all 9. Adding a new agent means adding a directory under `harnesses/` with
-9 `index.toml` files -- no Rust code changes.
-
-### Supported Agents
-
-aider, amp, claude, code, codex, copilot, crush, cursor-agent, droid, eca,
-forge, gemini, goose, hermes, jules, kilocode, letta, llxprt, nanocoder,
-ollama, openclaw, opencode, pi, qwen, vibe
+# Homebrew
+brew install BA-CalderonMorales/homebrew-terminal-jarvis/terminal-jarvis
+```
 
 ## Quick Start
 
 ```bash
-# List every available coding agent
-cargo run -- list
+# List every coding agent
+terminal-jarvis list
 
-# Inspect a harness and its capabilities
-cargo run -- show opencode
+# Inspect a harness
+terminal-jarvis show opencode
 
-# Preview the command for a capability
-cargo run -- plan codex headless
+# Preview a capability command
+terminal-jarvis plan codex headless
 
-# Select an active harness
-cargo run -- use opencode
-cargo run -- current
-
-# Check what's ready to run
-cargo run -- check
+# Select and verify the active harness
+terminal-jarvis use opencode
+terminal-jarvis current
+terminal-jarvis check
 ```
 
-### Verification
+For development builds, replace `terminal-jarvis` with `cargo run --`.
 
-```bash
-scripts/verify.sh              # fmt, lint, tests, shape, hardening, security
-scripts/local-ci.sh            # stronger gate with repository hygiene
-scripts/local-cd.sh --check-auth  # release asset shape without publishing
-```
-
-## How It Works
+### Layout
 
 ```text
-terminal-jarvis/
-├── harnesses/      # 25 agents, 9 capabilities each = 225 index.toml files
-│   └── <agent>/
-│       ├── index.toml         # name, display, binary, env requirements
-│       ├── download/index.toml
-│       ├── update/index.toml
-│       ├── headless/index.toml
-│       ├── version/index.toml
-│       ├── stats/index.toml
-│       ├── models/index.toml
-│       ├── security/index.toml
-│       ├── yolo/index.toml
-│       └── ui/index.toml
-├── src/            # Rust CLI (kept under 100 lines per file)
-├── tests/          # contract, CLI, and integration tests
-└── docs/           # architecture, testing, release, migration
+harnesses/<agent>/
+├── index.toml              # name, display, binary, env requirements
+├── download/index.toml     # install without sudo
+├── update/index.toml       # upgrade without interactive auth
+├── headless/index.toml     # non-interactive command mode
+├── version/index.toml      # print installed agent version
+├── stats/index.toml        # local agent statistics
+├── models/index.toml       # list available models
+├── security/index.toml     # sandbox and approval settings
+├── ui/index.toml           # interactive terminal UI
+└── yolo/index.toml         # bypass safeguards (dangerous)
 ```
 
-Auth setup lives at the harness level (`env_mode`, `env`). A harness can
-require no key, one of several, or all listed. Setup guidance stays accurate
-without forcing every provider key.
+Auth stays with each harness -- terminal-jarvis never retains credentials.
 
-## Development
+## Commands
 
-- **Branch strategy**: feature branches from `develop`, PRs against `develop`.
-  `main` is for tagged releases only.
-- **CI**: runs on every PR not limited to docs. Docs-only changes skip CI
-  (trigger manually via `workflow_dispatch` if needed).
-- **File discipline**: keep Rust source files at 100 lines or fewer. Prefer
-  `index.toml` data over Rust conditionals. Zero dependencies until one proves
-  its value.
-- **Environment**: use a remote or disposable Linux workspace. Harnesses
-  install binaries and run delegated commands; keep provider tokens scoped and
-  test on short-lived environments.
+| Command | Purpose |
+|---|---|
+| `list` | Show all coding agents |
+| `show <harness>` | Inspect a harness's capabilities |
+| `use <harness>` / `current` | Select / show active harness |
+| `plan [harness] <capability>` | Preview the shell command |
+| `run [harness] [capability] [args...]` | Execute a capability |
+| `check` | Report binary + env readiness |
+| `security [status\|audit\|harness]` | Security posture |
+| `version [--verbose]` / `--version` / `-v` / `--info` | Version info |
+| `config show` | Active config state |
+| `auth help <harness>` | Credential setup guidance |
+| `[harness] [args...]` | Pass-through to harness binary |
 
-## Release
+> Legacy aliases from 0.0.x: see [docs/migration.md](docs/migration.md).
 
-Cargo is the primary distribution. npm and Homebrew surfaces are generated
-from the same release build.
+## Docs
 
-```bash
-scripts/package-release.sh build dist/
-scripts/local-cd.sh --check-auth
-```
-
-Tagged releases (`v*`) trigger `.github/workflows/cd-multiplatform.yml`:
-crate publish, GitHub release assets, Homebrew tap update, and npm package.
-
-See [docs/release-plan.md](docs/release-plan.md) for the checklist and auth
-boundaries.
+| Document | What |
+|---|---|
+| [Capability contract](docs/harness-capability-contract.md) | Full breakdown of the 9 capabilities |
+| [Supported agents](docs/supported-agents.md) | All 25 coding agents |
+| [Maintainer guide](docs/maintainer-guide.md) | Development, verification, release |
+| [Architecture](docs/architecture.md) | Module boundaries and contracts |
+| [Release plan](docs/release-plan.md) | Checklist and auth boundaries |
+| [Migration](docs/migration.md) | Breaking changes from 0.0.x |
+| [Testing](docs/testing.md) | Test gates and integration hardening |
+| [Distribution hardening](docs/distribution-hardening.md) | Package integrity and provenance |

--- a/docs/harness-capability-contract.md
+++ b/docs/harness-capability-contract.md
@@ -1,0 +1,49 @@
+# Harness Capability Contract
+
+Every coding agent harness exposes the same 9 capabilities. Adding a new agent
+means adding 9 `index.toml` files under `harnesses/<agent>/` -- no Rust code
+changes.
+
+## Capabilities
+
+| Capability | Safety | Behavior |
+|---|---|---|
+| `download` | safe | Install the agent without sudo |
+| `update` | safe | Upgrade without interactive auth |
+| `headless` | safe | Run in non-interactive / command mode |
+| `version` | safe | Print the installed agent version |
+| `stats` | safe | Show local agent statistics |
+| `models` | safe | List available models |
+| `security` | safe | Review sandbox and approval settings |
+| `ui` | safe | Open the interactive terminal UI |
+| `yolo` | **dangerous** | Bypass all safeguards and approvals |
+
+8 safe capabilities, 1 dangerous. Every harness implements all 9.
+
+## Per-Harness Metadata
+
+Each harness `index.toml` declares:
+
+| Field | Purpose |
+|---|---|
+| `name` | Key used in CLI commands |
+| `display` | Human-readable name |
+| `description` | One-line summary |
+| `binary` | Expected executable name |
+| `env_mode` | `none`, `any`, or `all` |
+| `env` | List of required environment variables |
+
+Auth guidance stays at the harness level. Terminal Jarvis never retains
+credentials -- it tells you what each harness needs and lets you manage
+your own provider keys.
+
+## Adding a New Agent
+
+```bash
+mkdir -p harnesses/<agent>/{download,update,headless,version,stats,models,security,yolo,ui}
+```
+
+Write `index.toml` for the harness root and each capability. Each
+capability `index.toml` contains a `summary`, `command`, and `args`.
+
+Run `scripts/verify.sh` to validate the contract is met.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,17 @@
 # Terminal Jarvis Docs
 
-This repository now centers on the new Rust harness catalog CLI.
-
 The v0.1 minor line intentionally breaks old interfaces so the project can
 reduce build time, remove the Go ADK experiment from the active root, make
 package hygiene clearer, and keep release confidence tied to compact checks.
 
-The **command and capability contract tables** live in the root
-[README.md](../README.md) -- that is the source of truth for the tool's
-surface and every harness capability set.
+The root [README.md](../README.md) is the entry point with install, quick
+start, and the tool command reference.
 
 ## Documents
 
+- [[harness-capability-contract|Harness Capability Contract]]
+- [[supported-agents|Supported Agents]]
+- [[maintainer-guide|Maintainer Guide]]
 - [[architecture|Architecture]]
 - [[distribution-hardening|Distribution Hardening]]
 - [[migration|Migration]]

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,11 +9,11 @@ start, and the tool command reference.
 
 ## Documents
 
-- [[harness-capability-contract|Harness Capability Contract]]
-- [[supported-agents|Supported Agents]]
-- [[maintainer-guide|Maintainer Guide]]
-- [[architecture|Architecture]]
-- [[distribution-hardening|Distribution Hardening]]
-- [[migration|Migration]]
-- [[release-plan|Release Plan]]
-- [[testing|Testing]]
+- [Harness Capability Contract](harness-capability-contract.md)
+- [Supported Agents](supported-agents.md)
+- [Maintainer Guide](maintainer-guide.md)
+- [Architecture](architecture.md)
+- [Distribution Hardening](distribution-hardening.md)
+- [Migration](migration.md)
+- [Release Plan](release-plan.md)
+- [Testing](testing.md)

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -1,0 +1,56 @@
+# Maintainer Guide
+
+## Branch Strategy
+
+- **`develop`**: default base for PRs. Experimentation and quick iteration.
+- **`main`**: tagged releases only. PRs merge into `develop` first, then
+  `develop` fast-forwards into `main` at release time.
+- **Feature branches**: branch from `develop`, PR against `develop`.
+
+## CI
+
+Runs on every PR against `develop` or `main`. Docs-only changes (limited to
+`docs/`, `README.md`, `AGENTS.md`, `CLAUDE.md`) skip CI automatically.
+Trigger manually via `workflow_dispatch` when needed.
+
+## Verification
+
+```bash
+scripts/verify.sh              # fmt, lint, tests, shape, hardening, security
+scripts/local-ci.sh            # stronger gate with repository hygiene
+scripts/local-cd.sh --check-auth  # release asset shape without publishing
+```
+
+`verify.sh` runs formatting, clippy, tests, the 100-line Rust file invariant,
+harness catalog shape checks, CLI smoke checks, the integration hardening
+matrix, security tooling, npm audit, npm wrapper smoke checks, Homebrew
+formula syntax, and coverage/mutation gates.
+
+## Release
+
+Cargo is the primary distribution. npm and Homebrew surfaces are generated
+from the same release build.
+
+```bash
+scripts/package-release.sh build dist/
+scripts/local-cd.sh --check-auth
+```
+
+Tagged releases (`v*`) trigger `.github/workflows/cd-multiplatform.yml`:
+crate publish, GitHub release assets, Homebrew tap update, and npm package.
+
+See [release-plan.md](release-plan.md) for the checklist and auth boundaries.
+
+## File Discipline
+
+- Keep Rust source files at 100 lines or fewer.
+- Prefer `harnesses/*/*/index.toml` data over Rust conditionals.
+- Keep dependencies at zero until one proves its value.
+- Keep docs concise and tied to migration, architecture, testing, or release.
+
+## Environment
+
+Use a remote or disposable Linux workspace when exercising harness install,
+update, headless, or yolo commands. Harnesses install binaries, inspect
+repositories, and can run delegated commands. Keep provider tokens scoped
+and do not run unreviewed agent commands on a daily-driver machine.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,6 +1,28 @@
 # Migration
 
-The pre-rewrite implementation is intentionally pruned from the active root.
+The pre-rewrite implementation (0.0.x) is intentionally pruned from the
+active root. Use Git history for legacy reference.
+
+## Legacy Alias Mapping
+
+The v0.1 rewrite replaced old command names. The following aliases forward
+to the new equivalents:
+
+| Legacy (0.0.x) | Current (0.1+) |
+|---|---|
+| `tools` | `list` |
+| `status` | `check` |
+| `info <harness>` | `show <harness>` |
+| `install <harness>` | `run <harness> download` |
+| `update <harness>` | `run <harness> update` |
+
+## Known Breaks (0.0.x vs 0.1+)
+
+- The new root no longer exposes the old menu system.
+- The Go ADK is not part of the new root.
+- NPM is a minimal source-wrapper surface until release binaries are published.
+- Homebrew is source-build by default until versioned release formulas are
+  promoted with real archive checksums.
 
 ## Upgrade Path
 
@@ -8,15 +30,3 @@ The pre-rewrite implementation is intentionally pruned from the active root.
 2. Keep each promoted harness on the shared capability contract.
 3. Run `scripts/verify.sh` after each promotion.
 4. Use pull request CI to compare the new root against hosted checks.
-
-The first promotion pass covers 25 initial harnesses. Several capabilities
-intentionally point at `--help` or an explicit unavailable plan until the exact
-harness-specific command is verified.
-
-## Known Breaks
-
-- The new root no longer exposes the old menu system.
-- The Go ADK is not part of the new root.
-- NPM is a minimal source-wrapper surface until release binaries are published.
-- Homebrew is source-build by default until versioned release formulas are
-  promoted with real archive checksums.

--- a/docs/supported-agents.md
+++ b/docs/supported-agents.md
@@ -1,0 +1,31 @@
+# Supported Agents
+
+25 coding-agent CLIs, all mapped through the same 9-capability contract.
+
+| Agent | Description |
+|---|---|
+| aider | AI pair programming assistant that edits code in your local git repository |
+| amp | Sourcegraph's AI-powered code assistant with advanced context awareness |
+| claude | Anthropic's Claude for code assistance |
+| code | Fork of Codex AI -- multi-provider coding agent |
+| codex | OpenAI coding agent CLI |
+| copilot | GitHub Copilot CLI -- AI pair programming directly in your terminal |
+| crush | Charm's multi-model AI assistant with LSP |
+| cursor-agent | AI agent replicating Cursor's capabilities in the CLI |
+| droid | Factory AI's Droid -- automated coding engineer |
+| eca | Editor Code Assistant |
+| forge | AI-enhanced terminal development environment |
+| gemini | Google's Gemini CLI tool |
+| goose | Block's AI-powered coding assistant with developer toolkit integration |
+| hermes | Nous Research's terminal AI agent with CLI, TUI, tools, skills, and messaging gateway |
+| jules | Google's asynchronous coding agent in the terminal |
+| kilocode | Open-source AI coding agent |
+| letta | Memory-first coding agent |
+| llxprt | Multi-provider AI coding assistant |
+| nanocoder | Local-first coding agent |
+| ollama | Get up and running with large language models locally |
+| openclaw | Open-source AI coding assistant and multi-channel local gateway |
+| opencode | Terminal-based AI coding agent |
+| pi | Terminal-based coding agent |
+| qwen | Qwen coding assistant |
+| vibe | Minimal CLI coding agent by Mistral AI |


### PR DESCRIPTION
### README.md

Slimmed down. No longer carries full capability tables, agent lists, verification commands, or development/release sections. Focuses on:

1. One-liner + install (cargo, npm, homebrew)
2. Quick start with layout tree underneath
3. Compact command reference table
4. Cross-links to docs/ for everything else

### New docs/ pages

| Page | Content |
|---|---|
| `docs/harness-capability-contract.md` | Full 9-capability breakdown, per-harness metadata, adding a new agent |
| `docs/supported-agents.md` | All 25 agents with one-line descriptions |
| `docs/maintainer-guide.md` | Branch strategy, CI rules, verification, release, file discipline, environment safety |

### Updated docs/ pages

| Page | Change |
|---|---|
| `docs/migration.md` | Added legacy alias mapping table (0.0.x \-\> 0.1+) |
| `docs/index.md` | Added new pages, removed stale reference to in-README tables |

### Changes accounted from user feedback

- No "The Pattern" header — install is second section after title
- Quick Start shows both `terminal-jarvis` (installed) and mentions `cargo run --` for dev
- Auth kept brief — terminal-jarvis never retains credentials
- Verification, Development, Release moved to `docs/maintainer-guide.md`
- Legacy aliases moved to `docs/migration.md` as a mapping table