### PR TITLE
chore: update Cargo.lock for v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "terminal-jarvis"
-version = "0.1.3"
+version = "0.1.4"


### PR DESCRIPTION
Updates Cargo.lock to match the 0.1.4 version bump so the CD build passes the `--locked` check.