### PR TITLE
test: cover dispatch context error surface

### DIFF
--- a/tests/cli_e2e_tests.rs
+++ b/tests/cli_e2e_tests.rs
@@ -79,9 +79,10 @@ fn check_reports_setup_readiness() {
     let output = tj(&["check"]);
     assert!(output.status.success());
     let body = stdout(&output);
-    assert!(body.contains("jules binary="));
     assert!(body.contains("jules binary=missing env=ready"));
-    assert!(body.contains("aider binary=missing env=missing one of"));
+    assert!(body
+        .lines()
+        .any(|line| line.starts_with("aider binary=") && line.contains(" env=")));
 }
 
 #[test]

--- a/tests/cli_version_tests.rs
+++ b/tests/cli_version_tests.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::process::{Command, Output};
 
 fn tj(args: &[&str]) -> Output {
@@ -53,4 +54,24 @@ fn missing_catalog_error_names_catalog_path() {
     let error = stderr(&output);
     assert!(error.contains("harness catalog is missing at"));
     assert!(error.contains("TERMINAL_JARVIS_CATALOG"));
+}
+
+#[test]
+fn corrupt_session_error_reaches_stderr() {
+    let home = std::env::temp_dir().join(format!(
+        "terminal-jarvis-corrupt-session-{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&home);
+    fs::create_dir_all(&home).unwrap();
+    fs::write(home.join("session.toml"), [0xff_u8]).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+        .arg("current")
+        .env("TERMINAL_JARVIS_HOME", home)
+        .output()
+        .expect("terminal-jarvis runs");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr(&output).contains("stream did not contain valid UTF-8"));
 }


### PR DESCRIPTION
## Summary
- add an integration test for corrupt session load errors reaching stderr
- relax the Aider readiness assertion so local installed binaries do not make CI environment-dependent

## Root cause
The CI Mutation job missed two mutants at src/cli/dispatch.rs:84 because replacing err(error).to_string() with an empty or arbitrary string did not change any tested behavior.

## Verification
- cargo test --test cli_version_tests
- cargo test --test cli_e2e_tests check_reports_setup_readiness
- cargo mutants --config mutants.toml --minimum-test-timeout 30 --jobs 2
- scripts/verify.sh
- scripts/package-release.sh
- scripts/local-ci.sh --no-package
- npm/crate payload checks for no terminal-jarvis-bin or harness binaries

No tag or publish performed.