### PR TITLE
fix: harden wrapper cache and catalog UX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/BA-CalderonMorales/terminal-jarvis"
 readme = "README.md"
 keywords = ["cli", "ai", "agents", "harness"]
 categories = ["command-line-utilities", "development-tools"]
-include = ["src/**", "harnesses/**", "docs/**", "Cargo.toml", "README.md", "LICENSE"]
+include = ["build.rs", "src/**", "harnesses/**", "docs/**", "Cargo.toml", "README.md", "LICENSE"]
 
 [[bin]]
 name = "terminal-jarvis"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,46 @@
+use std::env;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+fn main() {
+    println!("cargo:rerun-if-changed=harnesses");
+    let root = Path::new("harnesses");
+    let mut files = Vec::new();
+    collect(root, root, &mut files).expect("catalog files are readable");
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+    write_module(files).expect("embedded catalog module is writable");
+}
+
+fn collect(root: &Path, dir: &Path, files: &mut Vec<(String, PathBuf)>) -> io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            collect(root, &path, files)?;
+        } else if path.file_name().is_some_and(|name| name == "index.toml") {
+            let rel = path
+                .strip_prefix(root)
+                .expect("catalog path is under root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            println!("cargo:rerun-if-changed={}", path.display());
+            files.push((rel, fs::canonicalize(path)?));
+        }
+    }
+    Ok(())
+}
+
+fn write_module(files: Vec<(String, PathBuf)>) -> io::Result<()> {
+    let out = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set"));
+    let mut module = fs::File::create(out.join("embedded_catalog.rs"))?;
+    writeln!(module, "pub const FILES: &[(&str, &str)] = &[")?;
+    for (rel, path) in files {
+        writeln!(
+            module,
+            "    ({rel:?}, include_str!({:?})),",
+            path.to_string_lossy()
+        )?;
+    }
+    writeln!(module, "];")
+}

--- a/npm/terminal-jarvis/bin/terminal-jarvis
+++ b/npm/terminal-jarvis/bin/terminal-jarvis
@@ -11,32 +11,42 @@ const here = __dirname;
 const pkg = require(path.resolve(here, "../package.json"));
 const repo = path.resolve(here, "../../..");
 
-main().catch((error) => {
-  console.error(`terminal-jarvis: ${error.message}`);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`terminal-jarvis: ${error.message}`);
+    process.exit(1);
+  });
+}
 
 async function main() {
-  const resolved = await resolveBinary();
-  const env = {
-    ...process.env,
-    TERMINAL_JARVIS_DISTRIBUTION: resolved.source,
-    TERMINAL_JARVIS_RELEASE_URL: resolved.releaseUrl || "",
-    TERMINAL_JARVIS_WRAPPER: __filename,
-  };
+  const resolved = await resolveBinary(args);
+  const env = childEnv(resolved);
   const result = spawnSync(resolved.binary, args, { stdio: "inherit", env });
+  if (result.error) throw new Error(`failed to execute ${resolved.binary}: ${result.error.message}`);
   process.exit(result.status ?? 1);
 }
 
-async function resolveBinary() {
+function childEnv(resolved) {
+  const env = {
+    ...process.env,
+    TERMINAL_JARVIS_DISTRIBUTION: resolved.source,
+    TERMINAL_JARVIS_WRAPPER: __filename,
+  };
+  if (resolved.releaseUrl) env.TERMINAL_JARVIS_RELEASE_URL = resolved.releaseUrl;
+  if (resolved.cache) env.TERMINAL_JARVIS_CACHE = process.env.TERMINAL_JARVIS_CACHE || resolved.cache;
+  if (!env.TERMINAL_JARVIS_CATALOG && resolved.catalog) env.TERMINAL_JARVIS_CATALOG = resolved.catalog;
+  return env;
+}
+
+async function resolveBinary(argv = args) {
   if (process.env.TERMINAL_JARVIS_BIN) {
     return explicit(process.env.TERMINAL_JARVIS_BIN, "env");
   }
   for (const candidate of sourceCandidates()) {
-    if (fs.existsSync(candidate)) return explicit(candidate, "source");
+    if (fs.existsSync(candidate.binary)) return explicit(candidate.binary, "source", candidate.catalog);
   }
   if (fs.existsSync(path.resolve(repo, "Cargo.toml"))) {
-    const result = spawnSync("cargo", ["run", "--quiet", "--", ...args], {
+    const result = spawnSync("cargo", ["run", "--quiet", "--", ...argv], {
       cwd: repo,
       stdio: "inherit",
     });
@@ -45,15 +55,16 @@ async function resolveBinary() {
   return downloadRelease();
 }
 
-function explicit(binary, source) {
+function explicit(binary, source, catalog = "") {
   if (!fs.existsSync(binary)) throw new Error(`binary not found: ${binary}`);
-  return { binary, source };
+  return { binary, source, catalog };
 }
 
 function sourceCandidates() {
+  const catalog = path.resolve(repo, "harnesses");
   return [
-    path.resolve(repo, "target/release/terminal-jarvis"),
-    path.resolve(repo, "target/debug/terminal-jarvis"),
+    { binary: path.resolve(repo, "target/release/terminal-jarvis"), catalog },
+    { binary: path.resolve(repo, "target/debug/terminal-jarvis"), catalog },
   ];
 }
 
@@ -63,22 +74,69 @@ async function downloadRelease() {
   const base = releaseBase();
   const releaseUrl = `${base}/${archive}`;
   const checksumUrl = `${releaseUrl}.sha256`;
-  const root = path.join(cacheRoot(), pkg.version, platform);
+  const cache = cacheRoot();
+  const root = path.join(cache, pkg.version, platform);
   const unpacked = path.join(root, `${pkg.name}-${pkg.version}-${platform}`);
   const binary = path.join(unpacked, "bin", "terminal-jarvis");
-  if (fs.existsSync(binary)) return { binary, source: "github-release-cache", releaseUrl };
+  const catalog = path.join(unpacked, "harnesses");
+  if (cachedReleaseUsable(binary, catalog)) {
+    fs.chmodSync(binary, 0o755);
+    return { binary, source: "github-release-cache", releaseUrl, cache, catalog };
+  }
   if (process.env.TERMINAL_JARVIS_NO_DOWNLOAD) {
+    if (fs.existsSync(binary) || fs.existsSync(catalog)) {
+      throw new Error(`cached release is not usable: ${root}`);
+    }
     throw new Error(`release binary is not cached: ${binary}`);
   }
   fs.rmSync(root, { recursive: true, force: true });
   fs.mkdirSync(root, { recursive: true });
   const archivePath = path.join(root, archive);
-  await fetchFile(releaseUrl, archivePath);
-  await verifyChecksum(checksumUrl, archivePath);
-  untar(archivePath, root);
+  try {
+    await fetchFile(releaseUrl, archivePath);
+    await verifyChecksum(checksumUrl, archivePath);
+    untar(archivePath, root);
+  } catch (error) {
+    fs.rmSync(root, { recursive: true, force: true });
+    throw downloadFailure(releaseUrl, error);
+  }
   if (!fs.existsSync(binary)) throw new Error(`release archive missing ${binary}`);
+  if (!fs.existsSync(catalog)) throw new Error(`release archive missing ${catalog}`);
+  if (!cachedBinaryUsable(binary)) throw new Error(`release binary is not usable: ${binary}`);
   fs.chmodSync(binary, 0o755);
-  return { binary, source: "github-release", releaseUrl };
+  return { binary, source: "github-release", releaseUrl, cache, catalog };
+}
+
+function cachedReleaseUsable(binary, catalog) {
+  return cachedBinaryUsable(binary) && fs.existsSync(catalog);
+}
+
+function cachedBinaryUsable(binary) {
+  try {
+    if (!fs.statSync(binary).isFile()) return false;
+    const header = Buffer.alloc(4);
+    const fd = fs.openSync(binary, "r");
+    try {
+      if (fs.readSync(fd, header, 0, 4, 0) !== 4) return false;
+    } finally {
+      fs.closeSync(fd);
+    }
+    return hasNativeBinaryMagic(header);
+  } catch {
+    return false;
+  }
+}
+
+function hasNativeBinaryMagic(header) {
+  return ["7f454c46", "cffaedfe", "cefaedfe", "feedfacf", "feedface", "cafebabe"]
+    .includes(header.toString("hex"));
+}
+
+function downloadFailure(releaseUrl, error) {
+  return new Error(
+    `failed to download Terminal Jarvis release from ${releaseUrl}: ${error.message}; ` +
+    "check network access or TERMINAL_JARVIS_RELEASE_BASE"
+  );
 }
 
 function platformName() {
@@ -129,3 +187,12 @@ function fetchFile(url, destination, redirects = 0) {
     }).on("error", reject);
   });
 }
+
+module.exports = {
+  cacheRoot,
+  cachedBinaryUsable,
+  cachedReleaseUsable,
+  childEnv,
+  downloadFailure,
+  platformName,
+};

--- a/npm/terminal-jarvis/package.json
+++ b/npm/terminal-jarvis/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build:rust": "cd ../.. && cargo build",
+    "test": "node --test test-wrapper.js",
     "smoke": "npm run build:rust && node bin/terminal-jarvis --help"
   },
   "keywords": [

--- a/npm/terminal-jarvis/test-wrapper.js
+++ b/npm/terminal-jarvis/test-wrapper.js
@@ -1,0 +1,50 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const wrapper = require("./bin/terminal-jarvis");
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "terminal-jarvis-wrapper-"));
+}
+
+test("cached binary validation rejects text files", () => {
+  const file = path.join(tempDir(), "terminal-jarvis");
+  fs.writeFileSync(file, "not a release binary\n");
+  fs.chmodSync(file, 0o755);
+  assert.equal(wrapper.cachedBinaryUsable(file), false);
+});
+
+test("cached release validation requires binary and catalog", () => {
+  const root = tempDir();
+  const binary = path.join(root, "bin", "terminal-jarvis");
+  const catalog = path.join(root, "harnesses");
+  fs.mkdirSync(path.dirname(binary), { recursive: true });
+  fs.writeFileSync(binary, Buffer.from([0x7f, 0x45, 0x4c, 0x46]));
+  assert.equal(wrapper.cachedReleaseUsable(binary, catalog), false);
+  fs.mkdirSync(catalog);
+  assert.equal(wrapper.cachedReleaseUsable(binary, catalog), true);
+});
+
+test("child environment pins wrapper cache and release catalog", () => {
+  const cache = path.join(tempDir(), "cache");
+  const catalog = path.join(tempDir(), "harnesses");
+  const env = wrapper.childEnv({
+    binary: "/tmp/terminal-jarvis",
+    source: "github-release-cache",
+    releaseUrl: "https://example.invalid/release.tgz",
+    cache,
+    catalog,
+  });
+  assert.equal(env.TERMINAL_JARVIS_CACHE, cache);
+  assert.equal(env.TERMINAL_JARVIS_CATALOG, catalog);
+  assert.equal(env.TERMINAL_JARVIS_DISTRIBUTION, "github-release-cache");
+});
+
+test("download errors name the release URL and override knob", () => {
+  const error = wrapper.downloadFailure("https://example.invalid/release.tgz", new Error("ENOTFOUND"));
+  assert.match(error.message, /failed to download Terminal Jarvis release/);
+  assert.match(error.message, /https:\/\/example\.invalid\/release\.tgz/);
+  assert.match(error.message, /TERMINAL_JARVIS_RELEASE_BASE/);
+});

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -48,6 +48,7 @@ scripts/security-check.sh
 
 echo "[9/11] distribution smoke"
 if command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+  npm --prefix npm/terminal-jarvis test
   npm --prefix npm/terminal-jarvis run smoke
   scripts/check-distribution-payloads.sh --npm-stage npm/terminal-jarvis
 else

--- a/src/catalog/embedded.rs
+++ b/src/catalog/embedded.rs
@@ -1,0 +1,63 @@
+use crate::contracts::{Capability, CapabilityPlan, CommandPlan, EnvMode, Harness};
+use std::collections::BTreeMap;
+use std::io;
+
+use super::parser::{self, Fields};
+
+include!(concat!(env!("OUT_DIR"), "/embedded_catalog.rs"));
+
+pub fn load() -> io::Result<Vec<Harness>> {
+    let mut grouped: BTreeMap<&str, BTreeMap<&str, &str>> = BTreeMap::new();
+    for (path, data) in FILES {
+        if let Some((name, file)) = path.split_once('/') {
+            grouped.entry(name).or_default().insert(file, data);
+        }
+    }
+    grouped
+        .into_values()
+        .map(|files| load_harness(&files))
+        .collect()
+}
+
+fn load_harness(files: &BTreeMap<&str, &str>) -> io::Result<Harness> {
+    let meta = fields(files, "index.toml")?;
+    let mut capabilities = Vec::new();
+    for capability in Capability::ALL {
+        capabilities.push(load_capability(files, capability)?);
+    }
+    Ok(Harness {
+        name: parser::string(&meta, "name").map_err(invalid)?,
+        display: parser::string(&meta, "display").map_err(invalid)?,
+        description: parser::string(&meta, "description").map_err(invalid)?,
+        binary: parser::string(&meta, "binary").map_err(invalid)?,
+        env_mode: EnvMode::parse(&parser::string(&meta, "env_mode").map_err(invalid)?)
+            .map_err(invalid)?,
+        env: parser::list(&meta, "env").map_err(invalid)?,
+        capabilities,
+    })
+}
+
+fn load_capability(
+    files: &BTreeMap<&str, &str>,
+    capability: Capability,
+) -> io::Result<CapabilityPlan> {
+    let path = format!("{}/index.toml", capability.as_str());
+    let data = fields(files, &path)?;
+    let command = parser::string(&data, "command").map_err(invalid)?;
+    Ok(CapabilityPlan {
+        capability,
+        summary: parser::string(&data, "summary").map_err(invalid)?,
+        command: CommandPlan::new(command, parser::list(&data, "args").map_err(invalid)?),
+    })
+}
+
+fn fields(files: &BTreeMap<&str, &str>, path: &str) -> io::Result<Fields> {
+    let data = files
+        .get(path)
+        .ok_or_else(|| invalid(format!("missing {path}")))?;
+    parser::parse(data).map_err(invalid)
+}
+
+fn invalid(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}

--- a/src/catalog/loader.rs
+++ b/src/catalog/loader.rs
@@ -1,11 +1,18 @@
 use crate::contracts::{Capability, CapabilityPlan, CommandPlan, EnvMode, Harness};
+use std::env;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-use super::parser::{self, Fields};
+use super::{
+    embedded,
+    parser::{self, Fields},
+};
 
 pub fn load(root: &Path) -> io::Result<Vec<Harness>> {
+    if should_use_embedded(root) {
+        return embedded::load();
+    }
     let mut harnesses = Vec::new();
     for dir in dirs(root)? {
         if dir.is_dir() {
@@ -13,6 +20,12 @@ pub fn load(root: &Path) -> io::Result<Vec<Harness>> {
         }
     }
     Ok(harnesses)
+}
+
+fn should_use_embedded(root: &Path) -> bool {
+    env::var_os("TERMINAL_JARVIS_CATALOG").is_none()
+        && root == Path::new("harnesses")
+        && !root.is_dir()
 }
 
 fn load_harness(dir: &Path) -> io::Result<Harness> {

--- a/src/catalog/loader.rs
+++ b/src/catalog/loader.rs
@@ -23,9 +23,11 @@ pub fn load(root: &Path) -> io::Result<Vec<Harness>> {
 }
 
 fn should_use_embedded(root: &Path) -> bool {
-    env::var_os("TERMINAL_JARVIS_CATALOG").is_none()
-        && root == Path::new("harnesses")
-        && !root.is_dir()
+    !catalog_env_set() && root == Path::new("harnesses") && !root.is_dir()
+}
+
+fn catalog_env_set() -> bool {
+    env::var_os("TERMINAL_JARVIS_CATALOG").is_some_and(|value| !value.is_empty())
 }
 
 fn load_harness(dir: &Path) -> io::Result<Harness> {

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -1,3 +1,4 @@
+mod embedded;
 mod loader;
 mod parser;
 mod validate;

--- a/src/cli/cache.rs
+++ b/src/cli/cache.rs
@@ -1,0 +1,51 @@
+use std::env;
+
+pub fn handle(words: &[String]) -> Result<String, String> {
+    match words {
+        [] => Ok(status()),
+        [action] if action == "status" => Ok(status()),
+        [action] if action == "clear" => Ok(clear()),
+        [action, ..] if action == "refresh" => Ok(refresh()),
+        _ => Err("usage: terminal-jarvis cache [status|clear|refresh]".to_string()),
+    }
+}
+
+fn status() -> String {
+    let distribution = distribution();
+    let release = release_line();
+    match cache_path() {
+        Some(path) => format!("cache: {path}\ndistribution: {distribution}\n{release}"),
+        None => format!("cache: unavailable\ndistribution: {distribution}\n{release}"),
+    }
+}
+
+fn clear() -> String {
+    match cache_path() {
+        Some(path) => format!("cache clear: remove {path} after terminal-jarvis exits\n"),
+        None => "cache clear: no wrapper cache path is active\n".to_string(),
+    }
+}
+
+fn refresh() -> String {
+    match cache_path() {
+        Some(path) => format!("cache refresh: remove {path}; the wrapper will fetch again\n"),
+        None => "cache refresh: no wrapper cache path is active\n".to_string(),
+    }
+}
+
+fn cache_path() -> Option<String> {
+    env::var("TERMINAL_JARVIS_CACHE")
+        .ok()
+        .filter(|value| !value.is_empty())
+}
+
+fn distribution() -> String {
+    env::var("TERMINAL_JARVIS_DISTRIBUTION").unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn release_line() -> String {
+    match env::var("TERMINAL_JARVIS_RELEASE_URL") {
+        Ok(url) if !url.is_empty() => format!("release: {url}\n"),
+        _ => String::new(),
+    }
+}

--- a/src/cli/cache.rs
+++ b/src/cli/cache.rs
@@ -40,7 +40,10 @@ fn cache_path() -> Option<String> {
 }
 
 fn distribution() -> String {
-    env::var("TERMINAL_JARVIS_DISTRIBUTION").unwrap_or_else(|_| "unknown".to_string())
+    env::var("TERMINAL_JARVIS_DISTRIBUTION")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 fn release_line() -> String {

--- a/src/cli/compat.rs
+++ b/src/cli/compat.rs
@@ -1,6 +1,9 @@
 use crate::context::Session;
-use crate::contracts::{Capability, Harness};
+use crate::contracts::{Capability, EnvMode, Harness};
+use crate::security;
 use std::path::Path;
+
+pub use super::cache::handle as cache;
 
 pub fn update_summary(harnesses: &[Harness]) -> String {
     let mut out = "updates are per harness in v0.1.2\n".to_string();
@@ -44,18 +47,6 @@ pub fn config(
     }
 }
 
-pub fn cache(words: &[String]) -> Result<String, String> {
-    match words {
-        [] => Ok("version cache: not used in v0.1.2\n".to_string()),
-        [action] if action == "status" => Ok("version cache: not used in v0.1.2\n".to_string()),
-        [action] if action == "clear" => Ok("version cache: no cache to clear\n".to_string()),
-        [action, ..] if action == "refresh" => {
-            Ok("version cache: refresh is unnecessary in v0.1.2\n".to_string())
-        }
-        _ => Err("usage: terminal-jarvis cache [status|clear|refresh]".to_string()),
-    }
-}
-
 pub fn legacy(command: &str) -> String {
     format!(
         "{command} was removed with the v0.1 catalog rewrite.\n\
@@ -69,11 +60,24 @@ fn auth_for(name: &str, harnesses: &[Harness]) -> Result<String, String> {
         .find(|harness| harness.name == name)
         .ok_or_else(|| format!("unknown harness '{name}'"))?;
     Ok(format!(
-        "auth for {} ({})\nsetup: {}\ncredential storage is not active in v0.1.2; export env vars in your shell\n",
+        "auth for {} ({})\nsetup: {}\nstatus: {}\ncredential storage is not active in v0.1.2; export env vars in your shell\n",
         harness.display,
         harness.name,
-        harness.setup_hint()
+        harness.setup_hint(),
+        auth_status(harness)
     ))
+}
+
+fn auth_status(harness: &Harness) -> String {
+    let missing = security::missing_env(harness);
+    if missing.is_empty() {
+        return "ready".to_string();
+    }
+    match harness.env_mode {
+        EnvMode::Any => format!("missing one of: {}", missing.join(", ")),
+        EnvMode::All => format!("missing: {}", missing.join(", ")),
+        EnvMode::None => "ready".to_string(),
+    }
 }
 
 fn auth_notice() -> String {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,6 @@
 mod action;
 pub mod args;
+mod cache;
 mod compat;
 mod dispatch;
 mod help;

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -16,6 +16,8 @@ pub fn text(verbose: bool, catalog: &Path, home: &Path) -> String {
     let wrapper = std::env::var("TERMINAL_JARVIS_WRAPPER").unwrap_or_default();
     let release = std::env::var("TERMINAL_JARVIS_RELEASE_URL")
         .unwrap_or_else(|_| format!("{REPO}/releases/tag/v{version}"));
+    let cache =
+        std::env::var("TERMINAL_JARVIS_CACHE").unwrap_or_else(|_| "unavailable".to_string());
     let wrapper_line = if wrapper.is_empty() {
         String::new()
     } else {
@@ -27,6 +29,7 @@ pub fn text(verbose: bool, catalog: &Path, home: &Path) -> String {
          distribution: {distribution}\n\
          git commit: {git_sha}\n\
          release: {release}\n\
+         cache: {cache}\n\
          catalog: {}\n\
          home: {}\n\
          {wrapper_line}",

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -11,13 +11,12 @@ pub fn text(verbose: bool, catalog: &Path, home: &Path) -> String {
         .map(|path| path.display().to_string())
         .unwrap_or_else(|_| "unknown".to_string());
     let git_sha = option_env!("TERMINAL_JARVIS_GIT_SHA").unwrap_or("unknown");
-    let distribution = nonempty_env("TERMINAL_JARVIS_DISTRIBUTION", "unknown");
+    let distribution = nonempty_env("TERMINAL_JARVIS_DISTRIBUTION", || "unknown".to_string());
     let wrapper = std::env::var("TERMINAL_JARVIS_WRAPPER").unwrap_or_default();
-    let release = nonempty_env(
-        "TERMINAL_JARVIS_RELEASE_URL",
-        &format!("{REPO}/releases/tag/v{version}"),
-    );
-    let cache = nonempty_env("TERMINAL_JARVIS_CACHE", "unavailable");
+    let release = nonempty_env("TERMINAL_JARVIS_RELEASE_URL", || {
+        format!("{REPO}/releases/tag/v{version}")
+    });
+    let cache = nonempty_env("TERMINAL_JARVIS_CACHE", || "unavailable".to_string());
     let wrapper_line = if wrapper.is_empty() {
         String::new()
     } else {
@@ -38,9 +37,12 @@ pub fn text(verbose: bool, catalog: &Path, home: &Path) -> String {
     )
 }
 
-fn nonempty_env(key: &str, fallback: &str) -> String {
+fn nonempty_env<F>(key: &str, fallback: F) -> String
+where
+    F: FnOnce() -> String,
+{
     std::env::var(key)
         .ok()
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| fallback.to_string())
+        .unwrap_or_else(fallback)
 }

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -11,13 +11,13 @@ pub fn text(verbose: bool, catalog: &Path, home: &Path) -> String {
         .map(|path| path.display().to_string())
         .unwrap_or_else(|_| "unknown".to_string());
     let git_sha = option_env!("TERMINAL_JARVIS_GIT_SHA").unwrap_or("unknown");
-    let distribution =
-        std::env::var("TERMINAL_JARVIS_DISTRIBUTION").unwrap_or_else(|_| "unknown".to_string());
+    let distribution = nonempty_env("TERMINAL_JARVIS_DISTRIBUTION", "unknown");
     let wrapper = std::env::var("TERMINAL_JARVIS_WRAPPER").unwrap_or_default();
-    let release = std::env::var("TERMINAL_JARVIS_RELEASE_URL")
-        .unwrap_or_else(|_| format!("{REPO}/releases/tag/v{version}"));
-    let cache =
-        std::env::var("TERMINAL_JARVIS_CACHE").unwrap_or_else(|_| "unavailable".to_string());
+    let release = nonempty_env(
+        "TERMINAL_JARVIS_RELEASE_URL",
+        &format!("{REPO}/releases/tag/v{version}"),
+    );
+    let cache = nonempty_env("TERMINAL_JARVIS_CACHE", "unavailable");
     let wrapper_line = if wrapper.is_empty() {
         String::new()
     } else {
@@ -36,4 +36,11 @@ pub fn text(verbose: bool, catalog: &Path, home: &Path) -> String {
         catalog.display(),
         home.display()
     )
+}
+
+fn nonempty_env(key: &str, fallback: &str) -> String {
+    std::env::var(key)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| fallback.to_string())
 }

--- a/src/context/session.rs
+++ b/src/context/session.rs
@@ -15,7 +15,7 @@ pub fn default_home() -> PathBuf {
 }
 
 pub fn catalog_root() -> PathBuf {
-    if let Some(path) = env::var_os("TERMINAL_JARVIS_CATALOG") {
+    if let Some(path) = env::var_os("TERMINAL_JARVIS_CATALOG").filter(|path| !path.is_empty()) {
         return PathBuf::from(path);
     }
     catalog_candidates()

--- a/tests/cli_auth_cache_tests.rs
+++ b/tests/cli_auth_cache_tests.rs
@@ -1,0 +1,78 @@
+use std::process::{Command, Output};
+
+fn tj(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+        .args(args)
+        .env(
+            "TERMINAL_JARVIS_HOME",
+            "/tmp/terminal-jarvis-auth-cache-test",
+        )
+        .env("TERMINAL_JARVIS_CACHE", "/tmp/terminal-jarvis-cache")
+        .env("TERMINAL_JARVIS_DISTRIBUTION", "github-release-cache")
+        .env(
+            "TERMINAL_JARVIS_RELEASE_URL",
+            "https://example.invalid/release.tgz",
+        )
+        .env_remove("OPENCODE_API_KEY")
+        .env_remove("OPENAI_API_KEY")
+        .output()
+        .expect("terminal-jarvis runs")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+#[test]
+fn cache_status_reports_wrapper_cache_metadata() {
+    let output = tj(&["cache", "status"]);
+    assert!(output.status.success());
+    let body = stdout(&output);
+    assert!(body.contains("cache: /tmp/terminal-jarvis-cache"));
+    assert!(body.contains("distribution: github-release-cache"));
+    assert!(body.contains("release: https://example.invalid/release.tgz"));
+}
+
+#[test]
+fn cache_without_subcommand_reports_status() {
+    let output = tj(&["cache"]);
+    assert!(output.status.success());
+    assert!(stdout(&output).contains("distribution: github-release-cache"));
+}
+
+#[test]
+fn cache_rejects_unknown_subcommands() {
+    let output = tj(&["cache", "unknown"]);
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr(&output).contains("usage: terminal-jarvis cache"));
+}
+
+#[test]
+fn cache_status_suppresses_empty_release_url() {
+    let output = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+        .args(["cache", "status"])
+        .env(
+            "TERMINAL_JARVIS_HOME",
+            "/tmp/terminal-jarvis-auth-cache-test",
+        )
+        .env("TERMINAL_JARVIS_CACHE", "/tmp/terminal-jarvis-cache")
+        .env("TERMINAL_JARVIS_DISTRIBUTION", "github-release-cache")
+        .env("TERMINAL_JARVIS_RELEASE_URL", "")
+        .output()
+        .expect("terminal-jarvis runs");
+    assert!(output.status.success());
+    assert!(!stdout(&output).contains("release:"));
+}
+
+#[test]
+fn auth_reports_missing_environment_status() {
+    let output = tj(&["auth", "opencode"]);
+    assert!(output.status.success());
+    let body = stdout(&output);
+    assert!(body.contains("setup: set one of: OPENCODE_API_KEY, OPENAI_API_KEY"));
+    assert!(body.contains("status: missing one of: OPENCODE_API_KEY, OPENAI_API_KEY"));
+}

--- a/tests/cli_auth_cache_tests.rs
+++ b/tests/cli_auth_cache_tests.rs
@@ -1,22 +1,36 @@
+use std::path::PathBuf;
 use std::process::{Command, Output};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-fn tj(args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+static TEMP_ID: AtomicUsize = AtomicUsize::new(0);
+const RELEASE: &str = "https://example.invalid/release.tgz";
+
+fn tj(args: &[&str]) -> (Output, PathBuf) {
+    let cache = temp_path("cache");
+    let output = base_command()
         .args(args)
-        .env(
-            "TERMINAL_JARVIS_HOME",
-            "/tmp/terminal-jarvis-auth-cache-test",
-        )
-        .env("TERMINAL_JARVIS_CACHE", "/tmp/terminal-jarvis-cache")
+        .env("TERMINAL_JARVIS_CACHE", &cache)
         .env("TERMINAL_JARVIS_DISTRIBUTION", "github-release-cache")
-        .env(
-            "TERMINAL_JARVIS_RELEASE_URL",
-            "https://example.invalid/release.tgz",
-        )
+        .env("TERMINAL_JARVIS_RELEASE_URL", RELEASE)
         .env_remove("OPENCODE_API_KEY")
         .env_remove("OPENAI_API_KEY")
         .output()
-        .expect("terminal-jarvis runs")
+        .expect("terminal-jarvis runs");
+    (output, cache)
+}
+
+fn base_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"));
+    command.env("TERMINAL_JARVIS_HOME", temp_path("home"));
+    command
+}
+
+fn temp_path(label: &str) -> PathBuf {
+    let id = TEMP_ID.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "terminal-jarvis-auth-cache-{label}-{}-{id}",
+        std::process::id()
+    ))
 }
 
 fn stdout(output: &Output) -> String {
@@ -29,37 +43,33 @@ fn stderr(output: &Output) -> String {
 
 #[test]
 fn cache_status_reports_wrapper_cache_metadata() {
-    let output = tj(&["cache", "status"]);
+    let (output, cache) = tj(&["cache", "status"]);
     assert!(output.status.success());
     let body = stdout(&output);
-    assert!(body.contains("cache: /tmp/terminal-jarvis-cache"));
+    assert!(body.contains(&format!("cache: {}", cache.display())));
     assert!(body.contains("distribution: github-release-cache"));
-    assert!(body.contains("release: https://example.invalid/release.tgz"));
+    assert!(body.contains(&format!("release: {RELEASE}")));
 }
 
 #[test]
 fn cache_without_subcommand_reports_status() {
-    let output = tj(&["cache"]);
+    let (output, _) = tj(&["cache"]);
     assert!(output.status.success());
     assert!(stdout(&output).contains("distribution: github-release-cache"));
 }
 
 #[test]
 fn cache_rejects_unknown_subcommands() {
-    let output = tj(&["cache", "unknown"]);
+    let (output, _) = tj(&["cache", "unknown"]);
     assert_eq!(output.status.code(), Some(2));
     assert!(stderr(&output).contains("usage: terminal-jarvis cache"));
 }
 
 #[test]
 fn cache_status_suppresses_empty_release_url() {
-    let output = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+    let output = base_command()
         .args(["cache", "status"])
-        .env(
-            "TERMINAL_JARVIS_HOME",
-            "/tmp/terminal-jarvis-auth-cache-test",
-        )
-        .env("TERMINAL_JARVIS_CACHE", "/tmp/terminal-jarvis-cache")
+        .env("TERMINAL_JARVIS_CACHE", temp_path("cache"))
         .env("TERMINAL_JARVIS_DISTRIBUTION", "github-release-cache")
         .env("TERMINAL_JARVIS_RELEASE_URL", "")
         .output()
@@ -69,8 +79,20 @@ fn cache_status_suppresses_empty_release_url() {
 }
 
 #[test]
+fn cache_status_treats_empty_distribution_as_unknown() {
+    let output = base_command()
+        .args(["cache", "status"])
+        .env("TERMINAL_JARVIS_CACHE", temp_path("cache"))
+        .env("TERMINAL_JARVIS_DISTRIBUTION", "")
+        .output()
+        .expect("terminal-jarvis runs");
+    assert!(output.status.success());
+    assert!(stdout(&output).contains("distribution: unknown"));
+}
+
+#[test]
 fn auth_reports_missing_environment_status() {
-    let output = tj(&["auth", "opencode"]);
+    let (output, _) = tj(&["auth", "opencode"]);
     assert!(output.status.success());
     let body = stdout(&output);
     assert!(body.contains("setup: set one of: OPENCODE_API_KEY, OPENAI_API_KEY"));

--- a/tests/cli_catalog_fallback_tests.rs
+++ b/tests/cli_catalog_fallback_tests.rs
@@ -36,6 +36,16 @@ fn tj_empty_catalog(args: &[&str], cwd: &PathBuf) -> Output {
         .expect("terminal-jarvis runs")
 }
 
+fn tj_catalog(args: &[&str], cwd: &PathBuf, catalog: &str) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+        .args(args)
+        .current_dir(cwd)
+        .env("TERMINAL_JARVIS_HOME", cwd.join("home"))
+        .env("TERMINAL_JARVIS_CATALOG", catalog)
+        .output()
+        .expect("terminal-jarvis runs")
+}
+
 fn stdout(output: &Output) -> String {
     String::from_utf8_lossy(&output.stdout).to_string()
 }
@@ -56,4 +66,11 @@ fn empty_catalog_env_still_uses_embedded_catalog() {
     let output = tj_empty_catalog(&["list"], &cwd);
     assert!(output.status.success());
     assert_eq!(stdout(&output).lines().count(), 25);
+}
+
+#[test]
+fn explicit_missing_catalog_path_stays_strict() {
+    let cwd = temp_dir();
+    let output = tj_catalog(&["list"], &cwd, "harnesses");
+    assert_eq!(output.status.code(), Some(2));
 }

--- a/tests/cli_catalog_fallback_tests.rs
+++ b/tests/cli_catalog_fallback_tests.rs
@@ -26,6 +26,16 @@ fn tj(args: &[&str], cwd: &PathBuf) -> Output {
         .expect("terminal-jarvis runs")
 }
 
+fn tj_empty_catalog(args: &[&str], cwd: &PathBuf) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+        .args(args)
+        .current_dir(cwd)
+        .env("TERMINAL_JARVIS_HOME", cwd.join("home"))
+        .env("TERMINAL_JARVIS_CATALOG", "")
+        .output()
+        .expect("terminal-jarvis runs")
+}
+
 fn stdout(output: &Output) -> String {
     String::from_utf8_lossy(&output.stdout).to_string()
 }
@@ -38,4 +48,12 @@ fn list_works_without_filesystem_catalog() {
     let body = stdout(&output);
     assert_eq!(body.lines().count(), 25);
     assert!(body.contains("codex - OpenAI coding agent CLI"));
+}
+
+#[test]
+fn empty_catalog_env_still_uses_embedded_catalog() {
+    let cwd = temp_dir();
+    let output = tj_empty_catalog(&["list"], &cwd);
+    assert!(output.status.success());
+    assert_eq!(stdout(&output).lines().count(), 25);
 }

--- a/tests/cli_catalog_fallback_tests.rs
+++ b/tests/cli_catalog_fallback_tests.rs
@@ -1,0 +1,41 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static TEMP_ID: AtomicUsize = AtomicUsize::new(0);
+
+fn temp_dir() -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "terminal-jarvis-catalog-fallback-{}-{}",
+        std::process::id(),
+        TEMP_ID.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = fs::remove_dir_all(&path);
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn tj(args: &[&str], cwd: &PathBuf) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+        .args(args)
+        .current_dir(cwd)
+        .env("TERMINAL_JARVIS_HOME", cwd.join("home"))
+        .env_remove("TERMINAL_JARVIS_CATALOG")
+        .output()
+        .expect("terminal-jarvis runs")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+#[test]
+fn list_works_without_filesystem_catalog() {
+    let cwd = temp_dir();
+    let output = tj(&["list"], &cwd);
+    assert!(output.status.success());
+    let body = stdout(&output);
+    assert_eq!(body.lines().count(), 25);
+    assert!(body.contains("codex - OpenAI coding agent CLI"));
+}

--- a/tests/cli_compat_surface_tests.rs
+++ b/tests/cli_compat_surface_tests.rs
@@ -58,9 +58,9 @@ mod unix {
         assert!(stdout(&tj(&["config", "show"], &home, None)).contains("active harness"));
         assert!(stdout(&tj(&["config", "path"], &home, None)).contains("catalog:"));
         assert!(stdout(&tj(&["config", "reset"], &home, None)).contains("not automatic"));
-        assert!(stdout(&tj(&["cache", "status"], &home, None)).contains("not used"));
-        assert!(stdout(&tj(&["cache", "clear"], &home, None)).contains("no cache"));
-        assert!(stdout(&tj(&["cache", "refresh"], &home, None)).contains("unnecessary"));
+        assert!(stdout(&tj(&["cache", "status"], &home, None)).contains("cache:"));
+        assert!(stdout(&tj(&["cache", "clear"], &home, None)).contains("cache clear:"));
+        assert!(stdout(&tj(&["cache", "refresh"], &home, None)).contains("cache refresh:"));
         assert!(stdout(&tj(&["security"], &home, None)).contains("jules binary="));
         assert!(stdout(&tj(&["security", "opencode"], &home, None)).contains("opencode:security"));
         assert!(stdout(&tj(&["security", "audit"], &home, None)).contains("jules binary="));

--- a/tests/cli_version_tests.rs
+++ b/tests/cli_version_tests.rs
@@ -41,6 +41,22 @@ fn verbose_version_reports_provenance_paths() {
 }
 
 #[test]
+fn verbose_version_ignores_empty_wrapper_env_values() {
+    let output = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+        .args(["version", "--verbose"])
+        .env("TERMINAL_JARVIS_DISTRIBUTION", "")
+        .env("TERMINAL_JARVIS_RELEASE_URL", "")
+        .env("TERMINAL_JARVIS_CACHE", "")
+        .output()
+        .expect("terminal-jarvis runs");
+    assert!(output.status.success());
+    let body = stdout(&output);
+    assert!(body.contains("distribution: unknown"));
+    assert!(body.contains("release: https://github.com/BA-CalderonMorales"));
+    assert!(body.contains("cache: unavailable"));
+}
+
+#[test]
 fn missing_catalog_error_names_catalog_path() {
     let output = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
         .arg("list")


### PR DESCRIPTION
## Summary
- applies the verified develop UX hardening to the main release lane
- embeds the catalog for cargo-installed binaries outside the repo
- hardens npm release cache validation, cache/catalog env reporting, and auth missing-env status

## Validation
- develop PR #144 passed Verify, Package Smoke, and Mutation before merge
- cargo test --test cli_auth_cache_tests --test cli_catalog_fallback_tests --test cli_compat_surface_tests
- npm --prefix npm/terminal-jarvis test
- git diff --check