### PR TITLE
fix: treat empty wrapper env values as unset

### DIFF
--- a/src/catalog/loader.rs
+++ b/src/catalog/loader.rs
@@ -23,9 +23,11 @@ pub fn load(root: &Path) -> io::Result<Vec<Harness>> {
 }
 
 fn should_use_embedded(root: &Path) -> bool {
-    env::var_os("TERMINAL_JARVIS_CATALOG").is_none()
-        && root == Path::new("harnesses")
-        && !root.is_dir()
+    !catalog_env_set() && root == Path::new("harnesses") && !root.is_dir()
+}
+
+fn catalog_env_set() -> bool {
+    env::var_os("TERMINAL_JARVIS_CATALOG").is_some_and(|value| !value.is_empty())
 }
 
 fn load_harness(dir: &Path) -> io::Result<Harness> {

--- a/src/cli/cache.rs
+++ b/src/cli/cache.rs
@@ -40,7 +40,10 @@ fn cache_path() -> Option<String> {
 }
 
 fn distribution() -> String {
-    env::var("TERMINAL_JARVIS_DISTRIBUTION").unwrap_or_else(|_| "unknown".to_string())
+    env::var("TERMINAL_JARVIS_DISTRIBUTION")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 fn release_line() -> String {

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -11,13 +11,12 @@ pub fn text(verbose: bool, catalog: &Path, home: &Path) -> String {
         .map(|path| path.display().to_string())
         .unwrap_or_else(|_| "unknown".to_string());
     let git_sha = option_env!("TERMINAL_JARVIS_GIT_SHA").unwrap_or("unknown");
-    let distribution = nonempty_env("TERMINAL_JARVIS_DISTRIBUTION", "unknown");
+    let distribution = nonempty_env("TERMINAL_JARVIS_DISTRIBUTION", || "unknown".to_string());
     let wrapper = std::env::var("TERMINAL_JARVIS_WRAPPER").unwrap_or_default();
-    let release = nonempty_env(
-        "TERMINAL_JARVIS_RELEASE_URL",
-        &format!("{REPO}/releases/tag/v{version}"),
-    );
-    let cache = nonempty_env("TERMINAL_JARVIS_CACHE", "unavailable");
+    let release = nonempty_env("TERMINAL_JARVIS_RELEASE_URL", || {
+        format!("{REPO}/releases/tag/v{version}")
+    });
+    let cache = nonempty_env("TERMINAL_JARVIS_CACHE", || "unavailable".to_string());
     let wrapper_line = if wrapper.is_empty() {
         String::new()
     } else {
@@ -38,9 +37,12 @@ pub fn text(verbose: bool, catalog: &Path, home: &Path) -> String {
     )
 }
 
-fn nonempty_env(key: &str, fallback: &str) -> String {
+fn nonempty_env<F>(key: &str, fallback: F) -> String
+where
+    F: FnOnce() -> String,
+{
     std::env::var(key)
         .ok()
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| fallback.to_string())
+        .unwrap_or_else(fallback)
 }

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -11,13 +11,13 @@ pub fn text(verbose: bool, catalog: &Path, home: &Path) -> String {
         .map(|path| path.display().to_string())
         .unwrap_or_else(|_| "unknown".to_string());
     let git_sha = option_env!("TERMINAL_JARVIS_GIT_SHA").unwrap_or("unknown");
-    let distribution =
-        std::env::var("TERMINAL_JARVIS_DISTRIBUTION").unwrap_or_else(|_| "unknown".to_string());
+    let distribution = nonempty_env("TERMINAL_JARVIS_DISTRIBUTION", "unknown");
     let wrapper = std::env::var("TERMINAL_JARVIS_WRAPPER").unwrap_or_default();
-    let release = std::env::var("TERMINAL_JARVIS_RELEASE_URL")
-        .unwrap_or_else(|_| format!("{REPO}/releases/tag/v{version}"));
-    let cache =
-        std::env::var("TERMINAL_JARVIS_CACHE").unwrap_or_else(|_| "unavailable".to_string());
+    let release = nonempty_env(
+        "TERMINAL_JARVIS_RELEASE_URL",
+        &format!("{REPO}/releases/tag/v{version}"),
+    );
+    let cache = nonempty_env("TERMINAL_JARVIS_CACHE", "unavailable");
     let wrapper_line = if wrapper.is_empty() {
         String::new()
     } else {
@@ -36,4 +36,11 @@ pub fn text(verbose: bool, catalog: &Path, home: &Path) -> String {
         catalog.display(),
         home.display()
     )
+}
+
+fn nonempty_env(key: &str, fallback: &str) -> String {
+    std::env::var(key)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| fallback.to_string())
 }

--- a/src/context/session.rs
+++ b/src/context/session.rs
@@ -15,7 +15,7 @@ pub fn default_home() -> PathBuf {
 }
 
 pub fn catalog_root() -> PathBuf {
-    if let Some(path) = env::var_os("TERMINAL_JARVIS_CATALOG") {
+    if let Some(path) = env::var_os("TERMINAL_JARVIS_CATALOG").filter(|path| !path.is_empty()) {
         return PathBuf::from(path);
     }
     catalog_candidates()

--- a/tests/cli_auth_cache_tests.rs
+++ b/tests/cli_auth_cache_tests.rs
@@ -1,22 +1,36 @@
+use std::path::PathBuf;
 use std::process::{Command, Output};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-fn tj(args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+static TEMP_ID: AtomicUsize = AtomicUsize::new(0);
+const RELEASE: &str = "https://example.invalid/release.tgz";
+
+fn tj(args: &[&str]) -> (Output, PathBuf) {
+    let cache = temp_path("cache");
+    let output = base_command()
         .args(args)
-        .env(
-            "TERMINAL_JARVIS_HOME",
-            "/tmp/terminal-jarvis-auth-cache-test",
-        )
-        .env("TERMINAL_JARVIS_CACHE", "/tmp/terminal-jarvis-cache")
+        .env("TERMINAL_JARVIS_CACHE", &cache)
         .env("TERMINAL_JARVIS_DISTRIBUTION", "github-release-cache")
-        .env(
-            "TERMINAL_JARVIS_RELEASE_URL",
-            "https://example.invalid/release.tgz",
-        )
+        .env("TERMINAL_JARVIS_RELEASE_URL", RELEASE)
         .env_remove("OPENCODE_API_KEY")
         .env_remove("OPENAI_API_KEY")
         .output()
-        .expect("terminal-jarvis runs")
+        .expect("terminal-jarvis runs");
+    (output, cache)
+}
+
+fn base_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"));
+    command.env("TERMINAL_JARVIS_HOME", temp_path("home"));
+    command
+}
+
+fn temp_path(label: &str) -> PathBuf {
+    let id = TEMP_ID.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "terminal-jarvis-auth-cache-{label}-{}-{id}",
+        std::process::id()
+    ))
 }
 
 fn stdout(output: &Output) -> String {
@@ -29,37 +43,33 @@ fn stderr(output: &Output) -> String {
 
 #[test]
 fn cache_status_reports_wrapper_cache_metadata() {
-    let output = tj(&["cache", "status"]);
+    let (output, cache) = tj(&["cache", "status"]);
     assert!(output.status.success());
     let body = stdout(&output);
-    assert!(body.contains("cache: /tmp/terminal-jarvis-cache"));
+    assert!(body.contains(&format!("cache: {}", cache.display())));
     assert!(body.contains("distribution: github-release-cache"));
-    assert!(body.contains("release: https://example.invalid/release.tgz"));
+    assert!(body.contains(&format!("release: {RELEASE}")));
 }
 
 #[test]
 fn cache_without_subcommand_reports_status() {
-    let output = tj(&["cache"]);
+    let (output, _) = tj(&["cache"]);
     assert!(output.status.success());
     assert!(stdout(&output).contains("distribution: github-release-cache"));
 }
 
 #[test]
 fn cache_rejects_unknown_subcommands() {
-    let output = tj(&["cache", "unknown"]);
+    let (output, _) = tj(&["cache", "unknown"]);
     assert_eq!(output.status.code(), Some(2));
     assert!(stderr(&output).contains("usage: terminal-jarvis cache"));
 }
 
 #[test]
 fn cache_status_suppresses_empty_release_url() {
-    let output = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+    let output = base_command()
         .args(["cache", "status"])
-        .env(
-            "TERMINAL_JARVIS_HOME",
-            "/tmp/terminal-jarvis-auth-cache-test",
-        )
-        .env("TERMINAL_JARVIS_CACHE", "/tmp/terminal-jarvis-cache")
+        .env("TERMINAL_JARVIS_CACHE", temp_path("cache"))
         .env("TERMINAL_JARVIS_DISTRIBUTION", "github-release-cache")
         .env("TERMINAL_JARVIS_RELEASE_URL", "")
         .output()
@@ -69,8 +79,20 @@ fn cache_status_suppresses_empty_release_url() {
 }
 
 #[test]
+fn cache_status_treats_empty_distribution_as_unknown() {
+    let output = base_command()
+        .args(["cache", "status"])
+        .env("TERMINAL_JARVIS_CACHE", temp_path("cache"))
+        .env("TERMINAL_JARVIS_DISTRIBUTION", "")
+        .output()
+        .expect("terminal-jarvis runs");
+    assert!(output.status.success());
+    assert!(stdout(&output).contains("distribution: unknown"));
+}
+
+#[test]
 fn auth_reports_missing_environment_status() {
-    let output = tj(&["auth", "opencode"]);
+    let (output, _) = tj(&["auth", "opencode"]);
     assert!(output.status.success());
     let body = stdout(&output);
     assert!(body.contains("setup: set one of: OPENCODE_API_KEY, OPENAI_API_KEY"));

--- a/tests/cli_catalog_fallback_tests.rs
+++ b/tests/cli_catalog_fallback_tests.rs
@@ -36,6 +36,16 @@ fn tj_empty_catalog(args: &[&str], cwd: &PathBuf) -> Output {
         .expect("terminal-jarvis runs")
 }
 
+fn tj_catalog(args: &[&str], cwd: &PathBuf, catalog: &str) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+        .args(args)
+        .current_dir(cwd)
+        .env("TERMINAL_JARVIS_HOME", cwd.join("home"))
+        .env("TERMINAL_JARVIS_CATALOG", catalog)
+        .output()
+        .expect("terminal-jarvis runs")
+}
+
 fn stdout(output: &Output) -> String {
     String::from_utf8_lossy(&output.stdout).to_string()
 }
@@ -56,4 +66,11 @@ fn empty_catalog_env_still_uses_embedded_catalog() {
     let output = tj_empty_catalog(&["list"], &cwd);
     assert!(output.status.success());
     assert_eq!(stdout(&output).lines().count(), 25);
+}
+
+#[test]
+fn explicit_missing_catalog_path_stays_strict() {
+    let cwd = temp_dir();
+    let output = tj_catalog(&["list"], &cwd, "harnesses");
+    assert_eq!(output.status.code(), Some(2));
 }

--- a/tests/cli_catalog_fallback_tests.rs
+++ b/tests/cli_catalog_fallback_tests.rs
@@ -26,6 +26,16 @@ fn tj(args: &[&str], cwd: &PathBuf) -> Output {
         .expect("terminal-jarvis runs")
 }
 
+fn tj_empty_catalog(args: &[&str], cwd: &PathBuf) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+        .args(args)
+        .current_dir(cwd)
+        .env("TERMINAL_JARVIS_HOME", cwd.join("home"))
+        .env("TERMINAL_JARVIS_CATALOG", "")
+        .output()
+        .expect("terminal-jarvis runs")
+}
+
 fn stdout(output: &Output) -> String {
     String::from_utf8_lossy(&output.stdout).to_string()
 }
@@ -38,4 +48,12 @@ fn list_works_without_filesystem_catalog() {
     let body = stdout(&output);
     assert_eq!(body.lines().count(), 25);
     assert!(body.contains("codex - OpenAI coding agent CLI"));
+}
+
+#[test]
+fn empty_catalog_env_still_uses_embedded_catalog() {
+    let cwd = temp_dir();
+    let output = tj_empty_catalog(&["list"], &cwd);
+    assert!(output.status.success());
+    assert_eq!(stdout(&output).lines().count(), 25);
 }

--- a/tests/cli_version_tests.rs
+++ b/tests/cli_version_tests.rs
@@ -41,6 +41,22 @@ fn verbose_version_reports_provenance_paths() {
 }
 
 #[test]
+fn verbose_version_ignores_empty_wrapper_env_values() {
+    let output = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+        .args(["version", "--verbose"])
+        .env("TERMINAL_JARVIS_DISTRIBUTION", "")
+        .env("TERMINAL_JARVIS_RELEASE_URL", "")
+        .env("TERMINAL_JARVIS_CACHE", "")
+        .output()
+        .expect("terminal-jarvis runs");
+    assert!(output.status.success());
+    let body = stdout(&output);
+    assert!(body.contains("distribution: unknown"));
+    assert!(body.contains("release: https://github.com/BA-CalderonMorales"));
+    assert!(body.contains("cache: unavailable"));
+}
+
+#[test]
 fn missing_catalog_error_names_catalog_path() {
     let output = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
         .arg("list")


### PR DESCRIPTION
## Summary
- treats empty TERMINAL_JARVIS_CATALOG as unset so embedded catalog fallback still works
- treats empty wrapper release/cache/distribution env vars as unset in version/cache output
- moves cache/auth test paths to std::env::temp_dir()-derived paths

## Validation
- cargo test --test cli_auth_cache_tests --test cli_catalog_fallback_tests --test cli_version_tests --test context_tests
- npm --prefix npm/terminal-jarvis test
- git diff --check
- Rust source/test line-count check