### PR TITLE
release: sync develop for 0.1.5

### DIFF
--- a/.github/workflows/cd-multiplatform.yml
+++ b/.github/workflows/cd-multiplatform.yml
@@ -25,6 +25,8 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - id: meta
         shell: bash
@@ -40,9 +42,11 @@ jobs:
             echo "release tag must look like vX.Y.Z: $tag" >&2
             exit 1
           }
+          git fetch --force --no-tags origin "+refs/heads/main:refs/remotes/origin/main"
+          git fetch --force --no-tags origin "+refs/tags/$tag:refs/tags/$tag"
+          git checkout --detach "refs/tags/$tag"
+          scripts/release-preflight.sh --tag "$tag" --expected-main-ref refs/remotes/origin/main
           version="${tag#v}"
-          cargo_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)"
-          test "$version" = "$cargo_version"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
@@ -63,6 +67,8 @@ jobs:
             os: macos-15
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.release-meta.outputs.tag }}
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -108,6 +114,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.release-meta.outputs.tag }}
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -143,6 +151,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.release-meta.outputs.tag }}
 
       - uses: actions/download-artifact@v8
         with:
@@ -196,6 +206,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           path: main
+          ref: ${{ needs.release-meta.outputs.tag }}
 
       - uses: actions/download-artifact@v8
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.5] - 2026-06-28
+
+- Adds a release preflight gate for tag, Cargo, npm, and main-tip alignment.
+- Makes CD release metadata failures explain the mismatch before packaging or
+  publishing starts.
+- Bumps the release candidate metadata to 0.1.5.
+- Keeps the 0.1.5 UX polish release notes intact for the recovered release.
+
 ## [0.1.4] - 2026-06-27
 
 - Adds missing CLI tests to kill surviving mutation-test mutants.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "terminal-jarvis"
-version = "0.1.4"
+version = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-jarvis"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "A data-driven harness switcher for AI coding agents"
 authors = ["BA-CalderonMorales"]

--- a/npm/terminal-jarvis/package-lock.json
+++ b/npm/terminal-jarvis/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terminal-jarvis",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "bin": {
         "terminal-jarvis": "bin/terminal-jarvis"

--- a/npm/terminal-jarvis/package.json
+++ b/npm/terminal-jarvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Data-driven harness switcher for AI coding agents",
   "bin": {
     "terminal-jarvis": "bin/terminal-jarvis"

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -55,24 +55,8 @@ skip_or_fail() {
   echo "skip: $tool not available. $hint"
 }
 
-cargo_version() {
-  sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1
-}
-
-json_version() {
-  sed -n 's/.*"version": "\([^"]*\)".*/\1/p' "$1" | head -n 1
-}
-
 check_versions() {
-  cargo=$(cargo_version)
-  npm=$(json_version npm/terminal-jarvis/package.json)
-  lock=$(json_version npm/terminal-jarvis/package-lock.json)
-  test -n "$cargo" || fail "Cargo.toml version missing"
-  test "$cargo" = "$npm" || fail "npm version $npm != Cargo version $cargo"
-  test "$cargo" = "$lock" || fail "package-lock version $lock != Cargo version $cargo"
-  grep -q "## \\[$cargo\\]" CHANGELOG.md ||
-    fail "CHANGELOG.md missing ## [$cargo]"
-  echo "versions ok: $cargo"
+  scripts/release-preflight.sh
 }
 
 check_ignores() {

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -45,10 +45,7 @@ test -n "$target" || fail "rustc host target missing"
 test -d harnesses || fail "harnesses directory missing"
 test -x npm/terminal-jarvis/bin/terminal-jarvis || fail "npm wrapper missing"
 
-npm_version=$(sed -n 's/.*"version": "\([^"]*\)".*/\1/p' \
-  npm/terminal-jarvis/package.json | head -n 1)
-test "$npm_version" = "$version" ||
-  fail "npm package version $npm_version does not match Cargo $version"
+scripts/release-preflight.sh
 
 if command -v ruby >/dev/null 2>&1; then
   ruby -c homebrew/Formula/terminal-jarvis.rb >/dev/null

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env sh
+set -eu
+
+cd "$(dirname "$0")/.."
+
+tag=
+expected_main_ref=
+
+fail() {
+  echo "release-preflight: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+usage: scripts/release-preflight.sh [--tag vX.Y.Z] [--expected-main-ref REF]
+
+Checks release metadata before packaging or publishing.
+EOF
+}
+
+value_from_cargo() {
+  sed -n "s/^$1 = \"\\([^\"]*\\)\"/\\1/p" Cargo.toml | head -n 1
+}
+
+json_version() {
+  sed -n 's/.*"version": "\([^"]*\)".*/\1/p' "$1" | head -n 1
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --tag) tag=${2:?missing tag}; shift ;;
+    --expected-main-ref) expected_main_ref=${2:?missing ref}; shift ;;
+    -h | --help) usage; exit 0 ;;
+    *) fail "unknown option $1" ;;
+  esac
+  shift
+done
+
+cargo_version=$(value_from_cargo version)
+npm_version=$(json_version npm/terminal-jarvis/package.json)
+lock_version=$(json_version npm/terminal-jarvis/package-lock.json)
+
+test -n "$cargo_version" || fail "Cargo.toml version missing"
+test -n "$npm_version" || fail "npm package version missing"
+test -n "$lock_version" || fail "npm package-lock version missing"
+test "$npm_version" = "$cargo_version" ||
+  fail "npm package version $npm_version does not match Cargo $cargo_version"
+test "$lock_version" = "$cargo_version" ||
+  fail "npm package-lock version $lock_version does not match Cargo $cargo_version"
+grep -q "## \\[$cargo_version\\]" CHANGELOG.md ||
+  fail "CHANGELOG.md missing ## [$cargo_version]"
+
+if [ -n "$expected_main_ref" ] && [ -z "$tag" ]; then
+  fail "--expected-main-ref requires --tag"
+fi
+
+if [ -n "$tag" ]; then
+  printf '%s\n' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' ||
+    fail "release tag must look like vX.Y.Z: $tag"
+  version=${tag#v}
+  test "$version" = "$cargo_version" ||
+    fail "release tag $tag does not match Cargo version $cargo_version"
+
+  tag_commit=$(git rev-parse -q --verify "refs/tags/$tag^{commit}") ||
+    fail "release tag not found: $tag"
+  head_commit=$(git rev-parse -q --verify "HEAD^{commit}") ||
+    fail "git HEAD is not a commit"
+  test "$head_commit" = "$tag_commit" ||
+    fail "checked-out HEAD $head_commit does not match $tag at $tag_commit"
+
+  if [ -n "$expected_main_ref" ]; then
+    main_commit=$(git rev-parse -q --verify "$expected_main_ref^{commit}") ||
+      fail "expected main ref not found: $expected_main_ref"
+    test "$tag_commit" = "$main_commit" ||
+      fail "$tag points to $tag_commit but $expected_main_ref is $main_commit"
+  fi
+fi
+
+echo "release preflight ok: $cargo_version"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -47,6 +47,7 @@ echo "[8/11] security"
 scripts/security-check.sh
 
 echo "[9/11] distribution smoke"
+scripts/release-preflight.sh
 if command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
   npm --prefix npm/terminal-jarvis test
   npm --prefix npm/terminal-jarvis run smoke

--- a/tests/release_preflight_tests.rs
+++ b/tests/release_preflight_tests.rs
@@ -1,0 +1,97 @@
+use std::{fs, path::Path, process::Command};
+
+fn make_root(name: &str) -> std::path::PathBuf {
+    let root = std::env::temp_dir().join(format!("terminal-jarvis-{name}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("scripts")).unwrap();
+    fs::create_dir_all(root.join("npm/terminal-jarvis")).unwrap();
+    fs::copy(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/release-preflight.sh"),
+        root.join("scripts/release-preflight.sh"),
+    )
+    .unwrap();
+    root
+}
+
+fn write_metadata(root: &Path, cargo: &str, npm: &str, lock: &str) {
+    fs::write(root.join("Cargo.toml"), format!("version = \"{cargo}\"\n")).unwrap();
+    fs::write(
+        root.join("npm/terminal-jarvis/package.json"),
+        format!("{{\"version\": \"{npm}\"}}\n"),
+    )
+    .unwrap();
+    fs::write(
+        root.join("npm/terminal-jarvis/package-lock.json"),
+        format!("{{\"version\": \"{lock}\"}}\n"),
+    )
+    .unwrap();
+    fs::write(root.join("CHANGELOG.md"), format!("## [{cargo}]\n")).unwrap();
+}
+
+fn run_preflight(root: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("sh")
+        .arg("scripts/release-preflight.sh")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .unwrap()
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .status()
+        .unwrap();
+    assert!(status.success(), "git {args:?} failed");
+}
+
+fn commit(root: &Path, message: &str) {
+    git(root, &["add", "."]);
+    git(
+        root,
+        &[
+            "-c",
+            "user.name=Terminal Jarvis",
+            "-c",
+            "user.email=tj@example.invalid",
+            "commit",
+            "-m",
+            message,
+        ],
+    );
+}
+
+#[test]
+fn metadata_version_mismatch_fails_clearly() {
+    let root = make_root("preflight-version-mismatch");
+    write_metadata(&root, "0.1.5", "0.1.4", "0.1.5");
+    let output = run_preflight(&root, &[]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("npm package version 0.1.4 does not match Cargo 0.1.5"));
+}
+
+#[test]
+fn matching_metadata_passes_without_tag_context() {
+    let root = make_root("preflight-metadata-ok");
+    write_metadata(&root, "0.1.5", "0.1.5", "0.1.5");
+    let output = run_preflight(&root, &[]);
+    assert!(output.status.success());
+}
+
+#[test]
+fn tag_must_match_expected_main_tip() {
+    let root = make_root("preflight-main-mismatch");
+    write_metadata(&root, "0.1.5", "0.1.5", "0.1.5");
+    git(&root, &["init", "-b", "main"]);
+    commit(&root, "release metadata");
+    git(&root, &["tag", "v0.1.5"]);
+    fs::write(root.join("after-tag.txt"), "new main tip\n").unwrap();
+    commit(&root, "advance main");
+    git(&root, &["checkout", "--detach", "v0.1.5"]);
+    let output = run_preflight(&root, &["--tag", "v0.1.5", "--expected-main-ref", "main"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("v0.1.5 points to") && stderr.contains("but main is"));
+}


### PR DESCRIPTION
## Summary

Sync `develop` into `main` for the 0.1.5 release recovery path after PR #148.

## Included Changes

- Release candidate metadata is bumped to `0.1.5`.
- Multi-Platform CD now runs `scripts/release-preflight.sh` before packaging or publishing.
- Release preflight checks Cargo, npm package, npm lockfile, changelog, requested tag, checked-out commit, and expected main tip alignment.
- Focused tests cover metadata mismatch and tag/main-tip mismatch failures.

## Validation Before This PR

- PR #148 to `develop` passed Verify, Package Smoke, and Mutation.
- Local validation included `cargo test`, npm tests, `scripts/verify.sh`, and `scripts/package-release.sh build /tmp/terminal-jarvis-0.1.5-preflight-dist`.

No tag movement, GitHub Release modification, asset upload, npm publish, crates.io publish, or Homebrew tap update is included here.