### PR TITLE
[codex] Fix npm stale global shim diagnostics

### DIFF
--- a/npm/terminal-jarvis/README.md
+++ b/npm/terminal-jarvis/README.md
@@ -6,6 +6,10 @@ The package does not include a native binary. Installed npm copies download the
 matching Terminal Jarvis archive from GitHub Releases, verify the release
 `.sha256` checksum, cache the unpacked binary, and execute it.
 
+Supported npm release assets are `linux-x64-gnu`, `macos-x64`, and
+`macos-arm64`. Native Windows installs through Git Bash or cmd are not
+supported until CI publishes a `win32-x64` asset; use WSL on Windows.
+
 In source checkouts it delegates to:
 
 1. `TERMINAL_JARVIS_BIN`

--- a/npm/terminal-jarvis/bin/terminal-jarvis
+++ b/npm/terminal-jarvis/bin/terminal-jarvis
@@ -140,10 +140,21 @@ function downloadFailure(releaseUrl, error) {
 }
 
 function platformName() {
-  if (process.platform === "linux" && process.arch === "x64") return "linux-x64-gnu";
-  if (process.platform === "darwin" && process.arch === "x64") return "macos-x64";
-  if (process.platform === "darwin" && process.arch === "arm64") return "macos-arm64";
-  throw new Error(`unsupported platform: ${process.platform}-${process.arch}`);
+  return platformNameFor(process.platform, process.arch);
+}
+
+function platformNameFor(platform, arch) {
+  if (platform === "linux" && arch === "x64") return "linux-x64-gnu";
+  if (platform === "darwin" && arch === "x64") return "macos-x64";
+  if (platform === "darwin" && arch === "arm64") return "macos-arm64";
+  throw new Error(unsupportedPlatformMessage(platform, arch));
+}
+
+function unsupportedPlatformMessage(platform, arch) {
+  const current = `${platform}-${arch}`;
+  return `unsupported platform: ${current}. ` +
+    "The npm package downloads GitHub Release assets for linux-x64-gnu, macos-x64, and macos-arm64. " +
+    "Native Windows npm installs are not supported until a win32-x64 asset is built in CI; use WSL on Windows.";
 }
 
 function releaseBase() {
@@ -154,6 +165,98 @@ function releaseBase() {
 function cacheRoot() {
   return process.env.TERMINAL_JARVIS_CACHE ||
     path.join(os.homedir() || os.tmpdir(), ".cache", "terminal-jarvis", "npm");
+}
+
+function pathEntries(pathValue = process.env.PATH || "") {
+  return pathValue.split(path.delimiter).filter(Boolean);
+}
+
+function commandExtensions(platform = process.platform, pathExt = process.env.PATHEXT || "") {
+  if (platform !== "win32") return [""];
+  const extensions = pathExt.split(";").filter(Boolean);
+  return ["", ...extensions].map((extension) => extension.toLowerCase());
+}
+
+function commandPathMatches(command, options = {}) {
+  const entries = pathEntries(options.pathValue);
+  const extensions = commandExtensions(options.platform, options.pathExt);
+  const names = extensions.map((extension) => `${command}${extension}`);
+  const matches = [];
+  for (const entry of entries) {
+    for (const name of names) {
+      const candidate = path.join(entry, name);
+      if (isExecutableFile(candidate)) matches.push(candidate);
+    }
+  }
+  return matches;
+}
+
+function isExecutableFile(candidate) {
+  try {
+    const stats = fs.statSync(candidate);
+    return stats.isFile() && (process.platform === "win32" || (stats.mode & 0o111) !== 0);
+  } catch {
+    return false;
+  }
+}
+
+function samePath(left, right, platform = process.platform) {
+  const normalize = (candidate) => {
+    const resolved = fs.existsSync(candidate) ? fs.realpathSync(candidate) : path.resolve(candidate);
+    return platform === "win32" ? resolved.toLowerCase() : resolved;
+  };
+  return normalize(left) === normalize(right);
+}
+
+function expectedGlobalShim(prefix = process.env.npm_config_prefix, platform = process.platform) {
+  if (!prefix) return "";
+  const binDir = platform === "win32" ? prefix : path.join(prefix, "bin");
+  return path.join(binDir, platform === "win32" ? "terminal-jarvis.cmd" : "terminal-jarvis");
+}
+
+function pathShadowStatus(options = {}) {
+  const command = options.command || "terminal-jarvis";
+  const expectedPaths = (options.expectedPaths || [__filename, expectedGlobalShim()])
+    .filter(Boolean);
+  const matches = commandPathMatches(command, options);
+  const expectedIndex = matches.findIndex((match) =>
+    expectedPaths.some((expected) => samePath(match, expected, options.platform))
+  );
+  if (expectedIndex === 0) return { kind: "ok", diagnostic: "" };
+  const expected = expectedIndex > 0 ? matches[expectedIndex] : expectedPaths[0];
+  const expectedDir = path.dirname(expected);
+  if (matches.length > 0) {
+    const first = matches[0];
+    const firstDir = path.dirname(first);
+    return {
+      kind: "shadow",
+      diagnostic: `terminal-jarvis: PATH resolves to ${first} before the npm shim ${expected}. ` +
+        `Remove or update the stale binary, or put ${expectedDir} before ${firstDir} in PATH.`,
+    };
+  }
+  return {
+    kind: "missing",
+    diagnostic: `terminal-jarvis: npm shim ${expected} is not reachable on PATH. Add ${expectedDir} to PATH.`,
+  };
+}
+
+function pathShadowDiagnostic(options = {}) {
+  return pathShadowStatus(options).diagnostic;
+}
+
+function shouldRunPostinstallDiagnostic(env = process.env) {
+  if (env.TERMINAL_JARVIS_SKIP_PATH_DIAGNOSTIC) return false;
+  return env.npm_config_global === "true" || env.npm_config_location === "global";
+}
+
+function postinstallPathStatus(env = process.env) {
+  if (!shouldRunPostinstallDiagnostic(env)) return { kind: "ok", diagnostic: "" };
+  return pathShadowStatus({
+    pathValue: env.PATH,
+    pathExt: env.PATHEXT,
+    platform: process.platform,
+    expectedPaths: [expectedGlobalShim(env.npm_config_prefix, process.platform), __filename],
+  });
 }
 
 async function verifyChecksum(checksumUrl, archivePath) {
@@ -194,5 +297,8 @@ module.exports = {
   cachedReleaseUsable,
   childEnv,
   downloadFailure,
+  pathShadowDiagnostic,
+  platformNameFor,
   platformName,
+  postinstallPathStatus,
 };

--- a/npm/terminal-jarvis/package-lock.json
+++ b/npm/terminal-jarvis/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "terminal-jarvis",
       "version": "0.1.5",
+      "hasInstallScript": true,
       "license": "MIT",
       "bin": {
         "terminal-jarvis": "bin/terminal-jarvis"

--- a/npm/terminal-jarvis/package.json
+++ b/npm/terminal-jarvis/package.json
@@ -7,11 +7,13 @@
   },
   "files": [
     "bin/",
+    "postinstall.js",
     "README.md",
     "package.json"
   ],
   "scripts": {
     "build:rust": "cd ../.. && cargo build",
+    "postinstall": "node postinstall.js",
     "test": "node --test test-wrapper.js",
     "smoke": "npm run build:rust && node bin/terminal-jarvis --help"
   },

--- a/npm/terminal-jarvis/postinstall.js
+++ b/npm/terminal-jarvis/postinstall.js
@@ -1,0 +1,5 @@
+const wrapper = require("./bin/terminal-jarvis");
+
+const status = wrapper.postinstallPathStatus();
+if (status.diagnostic) console.warn(status.diagnostic);
+if (status.kind === "shadow") process.exitCode = 1;

--- a/npm/terminal-jarvis/test-wrapper.js
+++ b/npm/terminal-jarvis/test-wrapper.js
@@ -2,11 +2,18 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const { spawnSync } = require("node:child_process");
 const test = require("node:test");
 const wrapper = require("./bin/terminal-jarvis");
 
 function tempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "terminal-jarvis-wrapper-"));
+}
+
+function writeExecutable(file, content) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+  fs.chmodSync(file, 0o755);
 }
 
 test("cached binary validation rejects text files", () => {
@@ -47,4 +54,74 @@ test("download errors name the release URL and override knob", () => {
   assert.match(error.message, /failed to download Terminal Jarvis release/);
   assert.match(error.message, /https:\/\/example\.invalid\/release\.tgz/);
   assert.match(error.message, /TERMINAL_JARVIS_RELEASE_BASE/);
+});
+
+test("platform mapping names published release assets", () => {
+  assert.equal(wrapper.platformNameFor("linux", "x64"), "linux-x64-gnu");
+  assert.equal(wrapper.platformNameFor("darwin", "x64"), "macos-x64");
+  assert.equal(wrapper.platformNameFor("darwin", "arm64"), "macos-arm64");
+});
+
+test("unsupported platform text gives Windows install guidance", () => {
+  assert.throws(
+    () => wrapper.platformNameFor("win32", "x64"),
+    /Native Windows npm installs are not supported.*use WSL on Windows/
+  );
+});
+
+test("wrapper forwards --version to the resolved binary", () => {
+  const fake = path.join(tempDir(), "terminal-jarvis");
+  writeExecutable(fake, "#!/usr/bin/env node\nconsole.log('fake ' + process.argv.slice(2).join(' '));\n");
+  const result = spawnSync(process.execPath, [path.join(__dirname, "bin", "terminal-jarvis"), "--version"], {
+    env: { ...process.env, TERMINAL_JARVIS_BIN: fake },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "fake --version");
+});
+
+test("path diagnostic reports stale binary before npm shim", () => {
+  const root = tempDir();
+  const stale = path.join(root, "cargo", "terminal-jarvis");
+  const shim = path.join(root, "npm", "terminal-jarvis");
+  writeExecutable(stale, "#!/bin/sh\n");
+  writeExecutable(shim, "#!/bin/sh\n");
+  const diagnostic = wrapper.pathShadowDiagnostic({
+    pathValue: `${path.dirname(stale)}${path.delimiter}${path.dirname(shim)}`,
+    expectedPaths: [shim],
+  });
+  assert.ok(diagnostic.includes(stale));
+  assert.ok(diagnostic.includes(shim));
+  assert.match(diagnostic, /before the npm shim/);
+});
+
+test("global postinstall fails when PATH shadows the npm shim", () => {
+  const root = tempDir();
+  const prefix = path.join(root, "node");
+  const stale = path.join(root, "cargo", "terminal-jarvis");
+  const shim = path.join(prefix, "bin", "terminal-jarvis");
+  writeExecutable(stale, "#!/bin/sh\n");
+  writeExecutable(shim, "#!/bin/sh\n");
+  const result = spawnSync(process.execPath, [path.join(__dirname, "postinstall.js")], {
+    cwd: __dirname,
+    env: {
+      ...process.env,
+      npm_config_global: "true",
+      npm_config_prefix: prefix,
+      PATH: `${path.dirname(stale)}${path.delimiter}${path.dirname(shim)}`,
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 1);
+  assert.ok(result.stderr.includes(stale));
+  assert.ok(result.stderr.includes(shim));
+});
+
+test("global postinstall path diagnostic supports explicit skip", () => {
+  const status = wrapper.postinstallPathStatus({
+    npm_config_global: "true",
+    TERMINAL_JARVIS_SKIP_PATH_DIAGNOSTIC: "1",
+  });
+  assert.equal(status.kind, "ok");
+  assert.equal(status.diagnostic, "");
 });

--- a/scripts/check-distribution-payloads.sh
+++ b/scripts/check-distribution-payloads.sh
@@ -27,6 +27,11 @@ test -d "$npm_stage" || fail "npm stage missing: $npm_stage"
 test ! -e "$npm_stage/bin/terminal-jarvis-bin" ||
   fail "npm package must not include terminal-jarvis-bin"
 
+if grep -q '"postinstall"' "$npm_stage/package.json"; then
+  test -f "$npm_stage/postinstall.js" ||
+    fail "npm package declares postinstall but does not include postinstall.js"
+fi
+
 for name in opencode codex claude gemini aider goose jules; do
   if find "$npm_stage" -type f -name "$name" | grep . >/dev/null; then
     fail "npm package must not include harness binary: $name"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -77,6 +77,7 @@ chmod +x "$stage/bin/$name"
 sha=$(cut -d ' ' -f 1 "$dist/$archive.sha256")
 
 cp npm/terminal-jarvis/package.json "$npm_stage/"
+cp npm/terminal-jarvis/postinstall.js "$npm_stage/"
 cp README.md "$npm_stage/"
 cp npm/terminal-jarvis/bin/terminal-jarvis "$npm_stage/bin/"
 chmod +x "$npm_stage/bin/terminal-jarvis"


### PR DESCRIPTION
## Summary

- Add npm wrapper platform mapping tests and clearer unsupported native Windows guidance.
- Add a global npm postinstall PATH diagnostic that fails loudly when a stale `terminal-jarvis` executable shadows the npm shim.
- Stage `postinstall.js` in release packaging and assert staged npm packages do not declare the hook without shipping it.

## Root Cause

The WSL global install issue was not the npm wrapper itself: PATH resolved `/home/caldo/.cargo/bin/terminal-jarvis` from an older Cargo install before the global npm shim. That stale binary rejected `--version`, while `npx terminal-jarvis@latest --version` used the current npm wrapper and worked.

Native Git Bash/cmd installs also failed with a terse `unsupported platform: win32-x64` because this release line does not publish Windows release assets.

## Validation

- `cargo test`
- `npm --prefix npm/terminal-jarvis test`
- `scripts/package-release.sh --check`
- `scripts/package-release.sh build /tmp/terminal-jarvis-post-015-package`
- `scripts/check-distribution-payloads.sh --npm-stage /tmp/terminal-jarvis-post-015-package/0.1.5/linux-x64-gnu/npm/terminal-jarvis`
- `npm pack --dry-run --json` from the staged npm package
- `scripts/verify.sh` (final rerun passed; coverage 93.71%; `cargo-audit`, `cargo-deny`, and mutation were skipped per local tool/env availability)
- GitNexus `detect_changes` on the staged patch and compare against `develop`: LOW risk, no affected execution flows

No tag, publish, or upload action was performed.