### PR TITLE
[codex] Refresh Grype code scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,49 @@ jobs:
           path: dist/**
           retention-days: 7
 
+  security-general:
+    name: Security - Grype SARIF
+    permissions:
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Scan workspace with Grype
+        id: grype
+        uses: anchore/scan-action@v7
+        with:
+          path: .
+          fail-build: false
+          output-format: sarif
+          cache-db: true
+
+      - name: Validate Grype SARIF output
+        run: |
+          set -eu
+          sarif_file="${{ steps.grype.outputs.sarif }}"
+          if [ -z "$sarif_file" ] || [ ! -s "$sarif_file" ]; then
+            echo "Grype SARIF output is missing: $sarif_file"
+            exit 1
+          fi
+          echo "Grype SARIF output is ready for upload: $sarif_file"
+
+      - name: Upload Grype SARIF report
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ steps.grype.outputs.sarif }}
+          category: security-general
+
+      - name: Fail on Grype findings
+        run: |
+          set -eu
+          sarif_file="${{ steps.grype.outputs.sarif }}"
+          findings="$(node -e "const fs=require('fs'); const s=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log((s.runs || []).reduce((n, run) => n + ((run.results || []).length), 0));" "$sarif_file")"
+          echo "Grype findings: $findings"
+          test "$findings" -eq 0
+
   mutation:
     name: Mutation
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Root cause

GitHub code scanning still has two open Grype alerts from the old `security-general` SARIF category even though the vulnerable paths were removed or fixed:

- Alert #10: `GHSA-mw96-cpmx-2vgc-rollup`, originally at `/e2e/package-lock.json`.
- Alert #7: `GHSA-8m95-fffc-h4c5-libsql-sqlite3-parser`, originally at `/Cargo.lock`.

The previous dependency fix removed the vulnerable dependency paths, and the later v0.1 prune removed `/e2e/package-lock.json`, but the current CI no longer uploads Grype SARIF for the `.github/workflows/ci.yml:security-general` analysis key. That left GitHub with stale open code scanning results and no fresh empty Grype run to mark them fixed.

## Fix

- Restores a narrow `security-general` CI job that runs Anchore/Grype on the current checkout.
- Uploads the SARIF with the same `security-general` category GitHub uses for the stale alerts.
- Fails the job if the generated SARIF contains any Grype findings.

## Validation

- GitHub code scanning API confirmed exactly two open alerts before the fix: #10 and #7.
- Local clean-source Grype 0.115.0 scan produced SARIF with `0` results.
- `cargo test`
- `npm --prefix npm/terminal-jarvis test`
- `scripts/verify.sh` (local `cargo-audit`, `cargo-deny`, and `cargo-mutants` unavailable/skipped; CI installs audit/deny)
- `scripts/package-release.sh --check`
- `scripts/package-release.sh build /tmp/terminal-jarvis-security-patch`
- `scripts/check-distribution-payloads.sh --npm-stage /tmp/terminal-jarvis-security-patch/0.1.5/linux-x64-gnu/npm/terminal-jarvis`
- `npm pack --dry-run --json --loglevel error` from the staged npm package
- `actionlint .github/workflows/ci.yml`
- GitNexus `detect_changes`: 1 workflow file, 0 changed symbols, 0 affected processes, low risk

No tags, releases, or release assets were created.