### PR TITLE
[codex] prepare terminal-jarvis 0.1.6 distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.6] - 2026-06-30
+
+- Hardens npm distribution as a launcher package with a real executable wrapper
+  and shipped `bin/README.txt` guidance instead of relying on local behavior.
+- Anchors crates.io package contents to the source, harness catalog, tests,
+  user-facing docs, changelog, README, lockfile, and license.
+- Keeps crates.io README rendering while excluding the large promo image from
+  the crate payload.
+- Aligns Homebrew tap generation and maintainer guidance with platform-specific
+  GitHub Release archives and checksums.
+
 ## [0.1.5] - 2026-06-28
 
 - Adds a release preflight gate for tag, Cargo, npm, and main-tip alignment.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "terminal-jarvis"
-version = "0.1.5"
+version = "0.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-jarvis"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "A data-driven harness switcher for AI coding agents"
 authors = ["BA-CalderonMorales"]
@@ -10,7 +10,18 @@ homepage = "https://github.com/BA-CalderonMorales/terminal-jarvis"
 readme = "README.md"
 keywords = ["cli", "ai", "agents", "harness"]
 categories = ["command-line-utilities", "development-tools"]
-include = ["build.rs", "src/**", "harnesses/**", "docs/**", "Cargo.toml", "README.md", "LICENSE"]
+include = [
+  "/Cargo.toml",
+  "/Cargo.lock",
+  "/build.rs",
+  "/src/**",
+  "/harnesses/**",
+  "/tests/**",
+  "/docs/*.md",
+  "/README.md",
+  "/CHANGELOG.md",
+  "/LICENSE",
+]
 
 [[bin]]
 name = "terminal-jarvis"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ interface.
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square)](https://ba-calderonmorales.github.io/my-life-as-a-dev/latest/projects/active/terminal-jarvis/)
 [![Coverage](https://img.shields.io/badge/coverage-report-green.svg?style=flat-square)](https://github.com/BA-CalderonMorales/terminal-jarvis/actions/workflows/ci.yml?query=branch%3Adevelop)
 
-<img src="docs/promo-image.png" alt="Terminal Jarvis Interface" width="100%">
+<img src="https://raw.githubusercontent.com/BA-CalderonMorales/terminal-jarvis/main/docs/promo-image.png" alt="Terminal Jarvis Interface" width="100%">
 
 </div>
 
@@ -46,6 +46,14 @@ npm install -g terminal-jarvis
 # Homebrew
 brew install BA-CalderonMorales/homebrew-terminal-jarvis/terminal-jarvis
 ```
+
+Cargo builds the Rust CLI from the crates.io source package. The npm package is
+a Node launcher that downloads the matching Terminal Jarvis GitHub Release
+asset, verifies its `.sha256` file, caches it, and then executes it. Homebrew is
+the binary installer path and installs the platform release archive from the tap.
+
+Supported prebuilt assets are `linux-x64-gnu`, `macos-x64`, and `macos-arm64`.
+Native Windows npm installs are not published yet; use WSL on Windows.
 
 ## Quick Start
 

--- a/docs/distribution-hardening.md
+++ b/docs/distribution-hardening.md
@@ -15,6 +15,26 @@ harness binary. Harness descriptors may name expected commands and reviewed
 install plans, but harness executables come from their upstream projects or the
 user's existing `PATH`.
 
+## Target Model
+
+- Cargo/crates.io is the source distribution. `cargo install terminal-jarvis`
+  builds the Rust CLI from the crate, using an anchored package allowlist that
+  includes only Cargo metadata, `Cargo.lock`, source, harness descriptors,
+  tests, user-facing docs, changelog, README, and license files.
+- npm is a launcher/helper distribution. The package ships a real executable
+  Node wrapper at `bin/terminal-jarvis` plus `bin/README.txt`; it does not ship
+  native binaries or harness executables. Installed copies download the matching
+  GitHub Release archive for the npm package version, verify the release
+  `.sha256` asset, cache the unpacked release, and execute it.
+- Homebrew is the binary installer path. The tap formula points at GitHub
+  Release archives with per-platform checksums and installs the
+  `terminal-jarvis` command plus the harness catalog.
+- The CLI command promise is the same across ecosystems: `terminal-jarvis`
+  exposes the same help, version/provenance output, harness list, and
+  capability commands. The packaging mechanics differ because Cargo builds from
+  source, npm launches a downloaded release asset, and Homebrew installs release
+  archives directly.
+
 ## Current Evidence
 
 - The git checkout tracks source, harness metadata, npm wrapper files, and
@@ -29,15 +49,15 @@ user's existing `PATH`.
 - Generated Homebrew formulas point at GitHub release archives. That is allowed
   because the binary source remains the GitHub Release asset, not the tap.
 
-## Required Change
+## Current Requirements
 
 Release packaging must keep `terminal-jarvis-bin` out of npm package payloads
 and workflow assertions.
 
-The npm package should become a small launcher that resolves the expected
+The npm package is a small launcher that resolves the expected
 Terminal Jarvis release asset for the current OS and CPU, verifies its checksum
 against the matching GitHub Release checksum, installs it into a user or npm
-cache, and then executes it. It should print the release URL and cached binary
+cache, and then executes it. It reports the release URL and cached binary
 path when asked for verbose version or provenance output.
 
 The launcher must fail closed when:
@@ -62,15 +82,13 @@ The launcher must fail closed when:
 - Update npm docs to state where the binary is downloaded from and how to
   inspect or clear the cache.
 
-### Current UX Hardening
+### Completed UX Hardening
 
 - Support `--version`, `-v`, `--info`, and `version --verbose`.
 - Treat `--info` as an alias for verbose provenance output.
 - Replace raw missing catalog `No such file or directory (os error 2)` failures
   with messages naming the catalog path and `TERMINAL_JARVIS_CATALOG`.
 - Reject unknown flags such as `--v` before loading the catalog.
-
-### Remaining `0.1.4` UX Fix
 
 - Detect stale global installs that still expose the pre-`0.1.2` help surface.
 - Make `npx terminal-jarvis`, global npm installs, Cargo installs, and Homebrew

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,10 +1,12 @@
 # Homebrew Surface
 
-This is the source-build Homebrew surface for the harness-catalog rewrite.
+This directory keeps the local source-build Homebrew smoke surface. The public
+tap at `BA-CalderonMorales/homebrew-terminal-jarvis` is the binary installer
+path and points at versioned GitHub Release archives with checksums.
 
-It is intentionally `head`-only until stable release archives and checksums are
-available. Release packaging generates versioned formulas under the configured
-package output directory.
+Release packaging generates versioned binary formulas under the configured
+package output directory, and the release workflow writes that formula into the
+tap.
 
 Local checks:
 

--- a/npm/terminal-jarvis/README.md
+++ b/npm/terminal-jarvis/README.md
@@ -2,13 +2,18 @@
 
 This is the npm launcher for Terminal Jarvis.
 
-The package does not include a native binary. Installed npm copies download the
-matching Terminal Jarvis archive from GitHub Releases, verify the release
-`.sha256` checksum, cache the unpacked binary, and execute it.
+The package does not include a native binary. Installed npm copies use
+`bin/terminal-jarvis`, a Node shebang wrapper, to download the matching Terminal
+Jarvis archive from GitHub Releases, verify the release `.sha256` checksum,
+cache the unpacked release, and execute it.
 
 Supported npm release assets are `linux-x64-gnu`, `macos-x64`, and
 `macos-arm64`. Native Windows installs through Git Bash or cmd are not
 supported until CI publishes a `win32-x64` asset; use WSL on Windows.
+
+The wrapper guidance shipped at `bin/README.txt` is included in the npm package
+so installed copies can explain the package behavior without relying on the
+source checkout.
 
 In source checkouts it delegates to:
 
@@ -19,6 +24,9 @@ In source checkouts it delegates to:
 
 Use `TERMINAL_JARVIS_CACHE` to choose the cache directory. Set
 `TERMINAL_JARVIS_NO_DOWNLOAD=1` to require an already-cached binary.
+
+Use `TERMINAL_JARVIS_RELEASE_BASE` only for a release mirror that preserves the
+exact package version and checksum files.
 
 Run the local smoke check:
 

--- a/npm/terminal-jarvis/bin/README.txt
+++ b/npm/terminal-jarvis/bin/README.txt
@@ -1,0 +1,29 @@
+terminal-jarvis npm launcher
+============================
+
+This directory contains the executable Node wrapper exposed by package.json#bin.
+It is not the Rust CLI binary.
+
+What it does:
+- Honors TERMINAL_JARVIS_BIN when you want to execute an explicit local binary.
+- In source checkouts, delegates to target/release, target/debug, or cargo run.
+- In installed npm packages, downloads the matching GitHub Release archive,
+  verifies the archive .sha256 file, caches the unpacked release, and executes
+  bin/terminal-jarvis from that cache.
+
+Supported downloaded assets:
+- linux-x64-gnu
+- macos-x64
+- macos-arm64
+
+Native Windows npm installs are not supported until a win32-x64 release asset is
+published. Use WSL on Windows.
+
+Useful environment variables:
+- TERMINAL_JARVIS_BIN: execute a specific local binary instead of downloading.
+- TERMINAL_JARVIS_CACHE: choose the release cache directory.
+- TERMINAL_JARVIS_NO_DOWNLOAD=1: require an already cached release.
+- TERMINAL_JARVIS_RELEASE_BASE: override the GitHub Release asset base URL.
+
+For source installs, use cargo install terminal-jarvis.
+For binary installs, use Homebrew or this npm wrapper.

--- a/npm/terminal-jarvis/bin/terminal-jarvis
+++ b/npm/terminal-jarvis/bin/terminal-jarvis
@@ -135,7 +135,8 @@ function hasNativeBinaryMagic(header) {
 function downloadFailure(releaseUrl, error) {
   return new Error(
     `failed to download Terminal Jarvis release from ${releaseUrl}: ${error.message}; ` +
-    "check network access or TERMINAL_JARVIS_RELEASE_BASE"
+    "check network access, proxy settings, offline cache, or TERMINAL_JARVIS_RELEASE_BASE. " +
+    guidanceHint()
   );
 }
 
@@ -154,7 +155,12 @@ function unsupportedPlatformMessage(platform, arch) {
   const current = `${platform}-${arch}`;
   return `unsupported platform: ${current}. ` +
     "The npm package downloads GitHub Release assets for linux-x64-gnu, macos-x64, and macos-arm64. " +
-    "Native Windows npm installs are not supported until a win32-x64 asset is built in CI; use WSL on Windows.";
+    "Native Windows npm installs are not supported until a win32-x64 asset is built in CI; use WSL on Windows. " +
+    guidanceHint();
+}
+
+function guidanceHint() {
+  return `See ${path.join(here, "README.txt")} for npm launcher behavior and install-path limits.`;
 }
 
 function releaseBase() {
@@ -297,6 +303,7 @@ module.exports = {
   cachedReleaseUsable,
   childEnv,
   downloadFailure,
+  guidanceHint,
   pathShadowDiagnostic,
   platformNameFor,
   platformName,

--- a/npm/terminal-jarvis/package-lock.json
+++ b/npm/terminal-jarvis/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terminal-jarvis",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/npm/terminal-jarvis/package.json
+++ b/npm/terminal-jarvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Data-driven harness switcher for AI coding agents",
   "bin": {
     "terminal-jarvis": "bin/terminal-jarvis"

--- a/npm/terminal-jarvis/test-wrapper.js
+++ b/npm/terminal-jarvis/test-wrapper.js
@@ -54,6 +54,7 @@ test("download errors name the release URL and override knob", () => {
   assert.match(error.message, /failed to download Terminal Jarvis release/);
   assert.match(error.message, /https:\/\/example\.invalid\/release\.tgz/);
   assert.match(error.message, /TERMINAL_JARVIS_RELEASE_BASE/);
+  assert.match(error.message, /bin[\/\\]README\.txt/);
 });
 
 test("platform mapping names published release assets", () => {
@@ -65,8 +66,22 @@ test("platform mapping names published release assets", () => {
 test("unsupported platform text gives Windows install guidance", () => {
   assert.throws(
     () => wrapper.platformNameFor("win32", "x64"),
-    /Native Windows npm installs are not supported.*use WSL on Windows/
+    /Native Windows npm installs are not supported.*use WSL on Windows.*README\.txt/
   );
+});
+
+test("npm pack ships wrapper guidance without native binaries", () => {
+  const result = spawnSync("npm", ["pack", "--dry-run", "--json", "--loglevel", "error"], {
+    cwd: __dirname,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const [pack] = JSON.parse(result.stdout);
+  const files = pack.files.map((file) => file.path);
+  assert.ok(files.includes("bin/README.txt"));
+  assert.ok(files.includes("bin/terminal-jarvis"));
+  assert.ok(!files.some((file) => file.endsWith("terminal-jarvis-bin")));
+  assert.ok(!files.some((file) => file.startsWith("harnesses/")));
 });
 
 test("wrapper forwards --version to the resolved binary", () => {

--- a/scripts/check-distribution-payloads.sh
+++ b/scripts/check-distribution-payloads.sh
@@ -23,6 +23,10 @@ done
 
 test -n "$npm_stage" || { usage; exit 2; }
 test -d "$npm_stage" || fail "npm stage missing: $npm_stage"
+test -x "$npm_stage/bin/terminal-jarvis" ||
+  fail "npm package must include executable bin/terminal-jarvis"
+test -f "$npm_stage/bin/README.txt" ||
+  fail "npm package must include bin/README.txt guidance"
 
 test ! -e "$npm_stage/bin/terminal-jarvis-bin" ||
   fail "npm package must not include terminal-jarvis-bin"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -79,6 +79,7 @@ sha=$(cut -d ' ' -f 1 "$dist/$archive.sha256")
 cp npm/terminal-jarvis/package.json "$npm_stage/"
 cp npm/terminal-jarvis/postinstall.js "$npm_stage/"
 cp README.md "$npm_stage/"
+cp npm/terminal-jarvis/bin/README.txt "$npm_stage/bin/"
 cp npm/terminal-jarvis/bin/terminal-jarvis "$npm_stage/bin/"
 chmod +x "$npm_stage/bin/terminal-jarvis"
 


### PR DESCRIPTION
## What changed

- Bumps terminal-jarvis release metadata to `0.1.6` across Cargo and npm.
- Hardens npm as a launcher package with a real executable wrapper and shipped `bin/README.txt` guidance.
- Anchors crates.io package contents to source, harness catalog, tests, docs, changelog, README, lockfile, and license.
- Keeps crates.io README rendering while excluding the large promo image from the crate payload.
- Updates distribution docs and release staging checks for the hardened npm payload.

## Why

This prepares the `0.1.6` release candidate while keeping GitHub Actions as the primary CI/CD path. Local package and publish dry-runs were used only as release-candidate validation, not deployment.

## Local validation

- `scripts/verify.sh`
- `scripts/local-ci.sh`
- `scripts/local-cd.sh --check-auth`
- `cargo publish --dry-run --allow-dirty`
- `npm publish --dry-run --tag latest` from the staged npm package
- GitNexus `detect_changes`: low risk, 0 affected indexed flows

## Release notes

After this PR lands, the release workflow expects `v0.1.6` to point at `origin/main`. The tag-push CD workflow should build Linux/macOS release assets, publish crates.io if needed, update the Homebrew tap, and publish or retag npm `latest`, `stable`, and `beta`.
