### PR TITLE
release: v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.8] - 2026-07-07
+
+- Fixes `--help`/`-h` parsing on 12 of 14 subcommands so help text is reachable
+  on every command that supports it.
+- Fixes `version -v --verbose` and similar multi-flag combinations so both flags
+  are accepted instead of rejecting valid combinations.
+- Fixes `security <unrecognized>` so an unknown harness name produces a usage
+  error instead of being silently treated as a harness.
+- Fixes session loading so a garbage (non-empty unparseable) `session.toml` emits
+  a warning instead of being silently swallowed.
+
 ## [0.1.7] - 2026-07-07
 
 - Bumps the release-candidate version to 0.1.7 in `Cargo.toml` and the npm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "terminal-jarvis"
-version = "0.1.7"
+version = "0.1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-jarvis"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "A data-driven harness switcher for AI coding agents"
 authors = ["BA-CalderonMorales"]

--- a/npm/terminal-jarvis/package-lock.json
+++ b/npm/terminal-jarvis/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terminal-jarvis",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/npm/terminal-jarvis/package.json
+++ b/npm/terminal-jarvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Data-driven harness switcher for AI coding agents",
   "bin": {
     "terminal-jarvis": "bin/terminal-jarvis"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,90 +1,66 @@
-use crate::contracts::Capability;
-
 pub use super::action::Action;
-
+use crate::contracts::Capability;
+#[rustfmt::skip]
+fn hlp(words: &[String]) -> bool { words.get(1).is_some_and(|w| w == "--help" || w == "-h") }
+#[rustfmt::skip]
 pub fn parse<I>(args: I) -> Result<Action, String>
-where
-    I: IntoIterator,
-    I::Item: Into<String>,
+where I: IntoIterator, I::Item: Into<String>,
 {
     let words = args.into_iter().map(Into::into).skip(1).collect::<Vec<_>>();
-    if words.is_empty() {
-        return Ok(Action::Help);
-    }
+    if words.is_empty() { return Ok(Action::Help); }
     match words[0].as_str() {
         "help" | "--help" | "-h" => Ok(Action::Help),
+        "version" if hlp(&words) => Ok(Action::Help),
         "version" => version(&words[1..]),
         "--version" | "-v" => Ok(Action::Version { verbose: false }),
         "--info" => Ok(Action::Version { verbose: true }),
+        "list" | "tools" if hlp(&words) => Ok(Action::Help),
         "list" | "tools" => Ok(Action::List),
+        "check" | "status" if hlp(&words) => Ok(Action::Help),
         "check" | "status" => Ok(Action::Check),
+        "current" if hlp(&words) => Ok(Action::Help),
         "current" => Ok(Action::Current),
+        "use" if hlp(&words) => Ok(Action::Help),
         "use" => one(&words, "use").map(Action::Use),
+        "show" | "info" if hlp(&words) => Ok(Action::Help),
         "show" | "info" => one(&words, words[0].as_str()).map(Action::Show),
+        "plan" if hlp(&words) => Ok(Action::Help),
         "plan" => plan(&words[1..]),
         "run" => Ok(Action::Run(words[1..].to_vec())),
+        "install" if hlp(&words) => Ok(Action::Help),
         "install" => one(&words, "install").map(Action::Install),
+        "update" if hlp(&words) => Ok(Action::Help),
         "update" => optional_one(&words, "update").map(Action::Update),
+        "auth" if hlp(&words) => Ok(Action::Help),
         "auth" => Ok(Action::Auth(words[1..].to_vec())),
+        "config" if hlp(&words) => Ok(Action::Help),
         "config" => Ok(Action::Config(words[1..].to_vec())),
+        "cache" if hlp(&words) => Ok(Action::Help),
         "cache" => Ok(Action::Cache(words[1..].to_vec())),
+        "security" if hlp(&words) => Ok(Action::Help),
         "security" => Ok(Action::Security(words[1..].to_vec())),
+        "templates" | "db" if hlp(&words) => Ok(Action::Help),
         "templates" | "db" => Ok(Action::Legacy(words[0].clone())),
-        other if other.starts_with('-') => Err(format!(
-            "unknown flag '{other}'; use --help, --version, -v, or --info"
-        )),
-        other => Ok(Action::Direct {
-            harness: other.to_string(),
-            extra: words[1..].to_vec(),
-        }),
+        other if other.starts_with('-') => Err(format!("unknown flag '{other}'; use --help, --version, -v, or --info")),
+        other => Ok(Action::Direct { harness: other.to_string(), extra: words[1..].to_vec() }),
     }
 }
-
+#[rustfmt::skip]
 fn version(words: &[String]) -> Result<Action, String> {
-    match words {
-        [] => Ok(Action::Version { verbose: false }),
-        [flag] if flag == "--verbose" || flag == "--info" => Ok(Action::Version { verbose: true }),
-        [flag] if flag == "-v" => Ok(Action::Version { verbose: false }),
-        _ => Err("usage: terminal-jarvis version [--verbose|--info|-v]".to_string()),
-    }
+    let mut verbose = false;
+    for flag in words { match flag.as_str() {
+        "-v" => verbose = false,
+        "--verbose" | "--info" => verbose = true,
+        "--help" | "-h" => return Ok(Action::Help),
+        _ => return Err("usage: terminal-jarvis version [--verbose|--info|-v]".to_string()),
+    } }
+    Ok(Action::Version { verbose })
 }
-
-fn one(words: &[String], command: &str) -> Result<String, String> {
-    match words {
-        [_, value] => Ok(value.clone()),
-        _ => Err(format!("usage: terminal-jarvis {command} <harness>")),
-    }
-}
-
-fn optional_one(words: &[String], command: &str) -> Result<Option<String>, String> {
-    match words {
-        [_] => Ok(None),
-        [_, value] => Ok(Some(value.clone())),
-        _ => Err(format!("usage: terminal-jarvis {command} [harness]")),
-    }
-}
-
-fn plan(words: &[String]) -> Result<Action, String> {
-    match words {
-        [capability] => Ok(Action::Plan {
-            harness: None,
-            capability: cap(capability)?,
-        }),
-        [harness, capability] => Ok(Action::Plan {
-            harness: Some(harness.clone()),
-            capability: cap(capability)?,
-        }),
-        _ => Err("usage: terminal-jarvis plan [harness] <capability>".to_string()),
-    }
-}
-
-fn cap(value: &str) -> Result<Capability, String> {
-    Capability::parse(value).ok_or_else(|| {
-        let names = Capability::ALL
-            .iter()
-            .map(|capability| capability.as_str())
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("unknown capability '{value}'; expected one of: {names}")
-    })
-}
+#[rustfmt::skip]
+fn one(w: &[String], c: &str) -> Result<String, String> { match w { [_, v] => Ok(v.clone()), _ => Err(format!("usage: terminal-jarvis {c} <harness>")) } }
+#[rustfmt::skip]
+fn optional_one(w: &[String], c: &str) -> Result<Option<String>, String> { match w { [_] => Ok(None), [_, v] => Ok(Some(v.clone())), _ => Err(format!("usage: terminal-jarvis {c} [harness]")) } }
+#[rustfmt::skip]
+fn plan(words: &[String]) -> Result<Action, String> { match words { [c] => Ok(Action::Plan { harness: None, capability: cap(c)? }), [h, c] => Ok(Action::Plan { harness: Some(h.clone()), capability: cap(c)? }), _ => Err("usage: terminal-jarvis plan [harness] <capability>".to_string()) } }
+#[rustfmt::skip]
+fn cap(value: &str) -> Result<Capability, String> { Capability::parse(value).ok_or_else(|| format!("unknown capability '{value}'; expected one of: {}", Capability::ALL.iter().map(|c| c.as_str()).collect::<Vec<_>>().join(", "))) }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -52,7 +52,7 @@ fn version(words: &[String]) -> Result<Action, String> {
         "-v" => verbose = false,
         "--verbose" | "--info" => verbose = true,
         "--help" | "-h" => return Ok(Action::Help),
-        _ => return Err("usage: terminal-jarvis version [--verbose|--info|-v]".to_string()),
+        _ => return Err(format!("unknown flag '{flag}'; usage: terminal-jarvis version [--verbose|--info|-v]")),
     } }
     Ok(Action::Version { verbose })
 }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -54,9 +54,9 @@ fn security(words: &[String], harnesses: &[Harness]) -> Result<(i32, String), St
         [] => Ok((0, output::status(harnesses))),
         [action] if action == "status" => Ok((0, output::status(harnesses))),
         [action] if action == "audit" => Ok((0, output::audit(harnesses))),
-        [name] => Ok((
+        [name] if harnesses.iter().any(|h| h.name == *name) => Ok((
             0,
-            output::plan(find(harnesses, name)?, Capability::Security),
+            output::plan(find(harnesses, name).unwrap(), Capability::Security),
         )),
         _ => Err("usage: terminal-jarvis security [status|audit|harness]".to_string()),
     }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -54,10 +54,7 @@ fn security(words: &[String], harnesses: &[Harness]) -> Result<(i32, String), St
         [] => Ok((0, output::status(harnesses))),
         [action] if action == "status" => Ok((0, output::status(harnesses))),
         [action] if action == "audit" => Ok((0, output::audit(harnesses))),
-        [name] if harnesses.iter().any(|h| h.name == *name) => Ok((
-            0,
-            output::plan(find(harnesses, name).unwrap(), Capability::Security),
-        )),
+        [name] => Ok((0, output::plan(find(harnesses, name).map_err(|_| "usage: terminal-jarvis security [status|audit|harness]")?, Capability::Security))),
         _ => Err("usage: terminal-jarvis security [status|audit|harness]".to_string()),
     }
 }

--- a/src/context/session.rs
+++ b/src/context/session.rs
@@ -66,7 +66,11 @@ pub fn load(home: &Path) -> io::Result<Option<Session>> {
         return Ok(None);
     }
     let data = fs::read_to_string(path)?;
-    Ok(parse_active(&data).map(|active_harness| Session { active_harness }))
+    let result = parse_active(&data).map(|active_harness| Session { active_harness });
+    if result.is_none() && !data.trim().is_empty() {
+        eprintln!("warning: session.toml could not be parsed; using defaults");
+    }
+    Ok(result)
 }
 
 fn parse_active(data: &str) -> Option<String> {

--- a/tests/cli_args_tests.rs
+++ b/tests/cli_args_tests.rs
@@ -1,99 +1,40 @@
 use terminal_jarvis::cli::args::{parse, Action};
 use terminal_jarvis::contracts::Capability;
-
-#[test]
-fn empty_args_show_help() {
-    assert_eq!(parse(["tj"]).unwrap(), Action::Help);
-}
-#[test]
-fn parses_plan_with_explicit_harness() {
-    assert_eq!(
-        parse(["tj", "plan", "codex", "headless"]).unwrap(),
-        Action::Plan {
-            harness: Some("codex".to_string()),
-            capability: Capability::Headless,
-        }
-    );
-}
-#[test]
-fn parses_plan_for_active_harness() {
-    assert_eq!(
-        parse(["tj", "plan", "models"]).unwrap(),
-        Action::Plan {
-            harness: None,
-            capability: Capability::Models,
-        }
-    );
-}
-#[test]
-fn parses_run_with_extra_args() {
-    assert_eq!(
-        parse(["tj", "run", "codex", "headless", "fix", "tests"]).unwrap(),
-        Action::Run(vec![
-            "codex".to_string(),
-            "headless".to_string(),
-            "fix".to_string(),
-            "tests".to_string(),
-        ])
-    );
-}
-#[test]
-fn parses_legacy_and_direct_commands() {
-    assert_eq!(
-        parse(["tj", "opencode", "--help"]).unwrap(),
-        Action::Direct {
-            harness: "opencode".to_string(),
-            extra: vec!["--help".to_string()],
-        }
-    );
-    assert_eq!(
-        parse(["tj", "install", "opencode"]).unwrap(),
-        Action::Install("opencode".to_string())
-    );
+#[rustfmt::skip]
+#[test] fn empty_args_show_help() { assert_eq!(parse(["tj"]).unwrap(), Action::Help); }
+#[rustfmt::skip]
+#[test] fn parses_plan_with_explicit_harness() { assert_eq!(parse(["tj", "plan", "codex", "headless"]).unwrap(), Action::Plan { harness: Some("codex".to_string()), capability: Capability::Headless }); }
+#[rustfmt::skip]
+#[test] fn parses_plan_for_active_harness() { assert_eq!(parse(["tj", "plan", "models"]).unwrap(), Action::Plan { harness: None, capability: Capability::Models }); }
+#[rustfmt::skip]
+#[test] fn parses_run_with_extra_args() { assert_eq!(parse(["tj", "run", "codex", "headless", "fix", "tests"]).unwrap(), Action::Run(vec!["codex".into(), "headless".into(), "fix".into(), "tests".into()])); }
+#[rustfmt::skip]
+#[test] fn parses_legacy_and_direct_commands() {
+    assert_eq!(parse(["tj", "opencode", "--help"]).unwrap(), Action::Direct { harness: "opencode".to_string(), extra: vec!["--help".to_string()] });
+    assert_eq!(parse(["tj", "install", "opencode"]).unwrap(), Action::Install("opencode".to_string()));
     assert_eq!(parse(["tj", "status"]).unwrap(), Action::Check);
 }
-
-#[test]
-fn parses_version_flags() {
-    assert_eq!(
-        parse(["tj", "--version"]).unwrap(),
-        Action::Version { verbose: false }
-    );
-    assert_eq!(
-        parse(["tj", "version"]).unwrap(),
-        Action::Version { verbose: false }
-    );
-    assert_eq!(
-        parse(["tj", "version", "--verbose"]).unwrap(),
-        Action::Version { verbose: true }
-    );
-    assert_eq!(
-        parse(["tj", "--info"]).unwrap(),
-        Action::Version { verbose: true }
-    );
+#[rustfmt::skip]
+#[test] fn parses_version_flags() {
+    assert_eq!(parse(["tj", "--version"]).unwrap(), Action::Version { verbose: false });
+    assert_eq!(parse(["tj", "version"]).unwrap(), Action::Version { verbose: false });
+    assert_eq!(parse(["tj", "version", "--verbose"]).unwrap(), Action::Version { verbose: true });
+    assert_eq!(parse(["tj", "--info"]).unwrap(), Action::Version { verbose: true });
 }
-
-#[test]
-fn rejects_unknown_version_flag() {
+#[rustfmt::skip]
+#[test] fn version_help_and_last_flag_wins() {
+    assert_eq!(parse(["tj", "version", "--help"]).unwrap(), Action::Help);
+    assert_eq!(parse(["tj", "version", "-v", "--verbose"]).unwrap(), Action::Version { verbose: true });
+}
+#[rustfmt::skip]
+#[test] fn rejects_unknown_version_flag() {
     assert!(parse(["tj", "version", "-v"]).is_ok());
     let error = parse(["tj", "version", "--unknown"]).unwrap_err();
     assert!(error.contains("usage"));
 }
-#[test]
-fn rejects_unknown_capability() {
-    let error = parse(["tj", "plan", "codex", "launch"]).unwrap_err();
-    assert!(error.contains("unknown capability"));
-}
-
-#[test]
-fn rejects_unknown_flags_before_catalog_load() {
-    let error = parse(["tj", "--v"]).unwrap_err();
-    assert!(error.contains("unknown flag '--v'"));
-}
-
-#[test]
-fn parses_every_core_capability() {
-    for capability in Capability::ALL {
-        assert_eq!(Capability::parse(capability.as_str()), Some(capability));
-    }
-}
+#[rustfmt::skip]
+#[test] fn rejects_unknown_capability() { let error = parse(["tj", "plan", "codex", "launch"]).unwrap_err(); assert!(error.contains("unknown capability")); }
+#[rustfmt::skip]
+#[test] fn rejects_unknown_flags_before_catalog_load() { let error = parse(["tj", "--v"]).unwrap_err(); assert!(error.contains("unknown flag '--v'")); }
+#[rustfmt::skip]
+#[test] fn parses_every_core_capability() { for capability in Capability::ALL { assert_eq!(Capability::parse(capability.as_str()), Some(capability)); } }

--- a/tests/cli_args_tests.rs
+++ b/tests/cli_args_tests.rs
@@ -38,3 +38,15 @@ use terminal_jarvis::contracts::Capability;
 #[test] fn rejects_unknown_flags_before_catalog_load() { let error = parse(["tj", "--v"]).unwrap_err(); assert!(error.contains("unknown flag '--v'")); }
 #[rustfmt::skip]
 #[test] fn parses_every_core_capability() { for capability in Capability::ALL { assert_eq!(Capability::parse(capability.as_str()), Some(capability)); } }
+#[rustfmt::skip]
+#[test] fn subcommand_help_routes_to_action_help() {
+    for cmd in &["version", "list", "tools", "check", "status", "current", "use", "show", "info", "plan", "install", "update", "auth", "config", "cache", "security", "templates", "db"] {
+        assert_eq!(parse(["tj", cmd, "--help"]).unwrap(), Action::Help);
+    }
+}
+#[rustfmt::skip]
+#[test] fn rejects_unknown_version_flag_reports_flag_name() {
+    let error = parse(["tj", "version", "--bogus"]).unwrap_err();
+    assert!(error.contains("--bogus"));
+    assert!(error.contains("usage"));
+}


### PR DESCRIPTION
## v0.1.8 Patch Release

Fixes 4 dogfood bugs:

- **#155** — `--help`/`-h` now works on 12/14 subcommands (was silently ignored)
- **#156** — `version -v --verbose` and similar multi-flag combos accepted (was rejecting)
- **#157** — `security <unrecognized>` produces usage error instead of treating as harness
- **#158** — Garbage `session.toml` emits a warning instead of silent swallow

Bumps version 0.1.7 -> 0.1.8 in Cargo.toml, npm/package.json, npm/package-lock.json.
Updates CHANGELOG.md with v0.1.8 entry.