### PR TITLE
fix: fmt dispatch.rs for CI compliance

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -54,7 +54,14 @@ fn security(words: &[String], harnesses: &[Harness]) -> Result<(i32, String), St
         [] => Ok((0, output::status(harnesses))),
         [action] if action == "status" => Ok((0, output::status(harnesses))),
         [action] if action == "audit" => Ok((0, output::audit(harnesses))),
-        [name] => Ok((0, output::plan(find(harnesses, name).map_err(|_| "usage: terminal-jarvis security [status|audit|harness]")?, Capability::Security))),
+        [name] => Ok((
+            0,
+            output::plan(
+                find(harnesses, name)
+                    .map_err(|_| "usage: terminal-jarvis security [status|audit|harness]")?,
+                Capability::Security,
+            ),
+        )),
         _ => Err("usage: terminal-jarvis security [status|audit|harness]".to_string()),
     }
 }


### PR DESCRIPTION
Runs cargo fmt on dispatch.rs so the security() arm is properly formatted.