### PR TITLE
release: v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.1.9] - 2026-07-07
+
+- Fixes `hlp()` helper to scan all arguments after the subcommand so `plan yolo --help`,
+  `security status --help`, `show opencode --help`, etc. route to help text. The `run`
+  subcommand still only checks position 1 so `run codex --help` forwards `--help` to
+  the harness as intended.
+- Fixes global `-v`/`--version`/`--info` to reject an unexpected subcommand after the
+  flag instead of silently discarding it: `terminal-jarvis -v version` and
+  `terminal-jarvis --info show opencode` now produce a clear error.
+- Fixes `npm postinstall` to exit 0 when a stale cargo binary shadows the npm shim on
+  PATH, so `npm install -g terminal-jarvis` no longer fails. The shadow warning is
+  still printed to stderr with actionable guidance.
+- Updates tests for all three bugfixes.
+
 ## [0.1.8] - 2026-07-07
 
 - Fixes `--help`/`-h` parsing on 12 of 14 subcommands so help text is reachable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "terminal-jarvis"
-version = "0.1.8"
+version = "0.1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-jarvis"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "A data-driven harness switcher for AI coding agents"
 authors = ["BA-CalderonMorales"]

--- a/npm/terminal-jarvis/package-lock.json
+++ b/npm/terminal-jarvis/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.1.8",
-  "lockfileVersion": 3,
+  "version": "0.1.9",
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "terminal-jarvis",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/npm/terminal-jarvis/package.json
+++ b/npm/terminal-jarvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Data-driven harness switcher for AI coding agents",
   "bin": {
     "terminal-jarvis": "bin/terminal-jarvis"

--- a/npm/terminal-jarvis/postinstall.js
+++ b/npm/terminal-jarvis/postinstall.js
@@ -2,4 +2,3 @@ const wrapper = require("./bin/terminal-jarvis");
 
 const status = wrapper.postinstallPathStatus();
 if (status.diagnostic) console.warn(status.diagnostic);
-if (status.kind === "shadow") process.exitCode = 1;

--- a/npm/terminal-jarvis/test-wrapper.js
+++ b/npm/terminal-jarvis/test-wrapper.js
@@ -110,7 +110,7 @@ test("path diagnostic reports stale binary before npm shim", () => {
   assert.match(diagnostic, /before the npm shim/);
 });
 
-test("global postinstall fails when PATH shadows the npm shim", () => {
+test("global postinstall warns on shadow but exits 0", () => {
   const root = tempDir();
   const prefix = path.join(root, "node");
   const stale = path.join(root, "cargo", "terminal-jarvis");
@@ -127,9 +127,10 @@ test("global postinstall fails when PATH shadows the npm shim", () => {
     },
     encoding: "utf8",
   });
-  assert.equal(result.status, 1);
+  assert.equal(result.status, 0);
   assert.ok(result.stderr.includes(stale));
   assert.ok(result.stderr.includes(shim));
+  assert.ok(result.stderr.includes("Remove or update"));
 });
 
 test("global postinstall path diagnostic supports explicit skip", () => {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,7 +1,7 @@
 pub use super::action::Action;
 use crate::contracts::Capability;
 #[rustfmt::skip]
-fn hlp(words: &[String]) -> bool { words.get(1).is_some_and(|w| w == "--help" || w == "-h") }
+fn hlp(words: &[String]) -> bool { words.iter().skip(1).any(|w| w == "--help" || w == "-h") }
 #[rustfmt::skip]
 pub fn parse<I>(args: I) -> Result<Action, String>
 where I: IntoIterator, I::Item: Into<String>,
@@ -12,8 +12,10 @@ where I: IntoIterator, I::Item: Into<String>,
         "help" | "--help" | "-h" => Ok(Action::Help),
         "version" if hlp(&words) => Ok(Action::Help),
         "version" => version(&words[1..]),
-        "--version" | "-v" => Ok(Action::Version { verbose: false }),
-        "--info" => Ok(Action::Version { verbose: true }),
+        "--version" | "-v" if words.len() == 1 => Ok(Action::Version { verbose: false }),
+        "--version" | "-v" => Err(format!("unexpected argument '{}' after --version/-v flag", words[1])),
+        "--info" if words.len() == 1 => Ok(Action::Version { verbose: true }),
+        "--info" => Err(format!("unexpected argument '{}' after --info flag", words[1])),
         "list" | "tools" if hlp(&words) => Ok(Action::Help),
         "list" | "tools" => Ok(Action::List),
         "check" | "status" if hlp(&words) => Ok(Action::Help),
@@ -26,7 +28,7 @@ where I: IntoIterator, I::Item: Into<String>,
         "show" | "info" => one(&words, words[0].as_str()).map(Action::Show),
         "plan" if hlp(&words) => Ok(Action::Help),
         "plan" => plan(&words[1..]),
-        "run" if hlp(&words) => Ok(Action::Help),
+        "run" if words.get(1).is_some_and(|w| w == "--help" || w == "-h") => Ok(Action::Help),
         "run" => Ok(Action::Run(words[1..].to_vec())),
         "install" if hlp(&words) => Ok(Action::Help),
         "install" => one(&words, "install").map(Action::Install),

--- a/tests/cli_args_tests.rs
+++ b/tests/cli_args_tests.rs
@@ -51,3 +51,30 @@ use terminal_jarvis::contracts::Capability;
     assert!(error.contains("--bogus"));
     assert!(error.contains("usage"));
 }
+#[rustfmt::skip]
+#[test] fn help_in_any_position_after_subcommand() {
+    assert_eq!(parse(["tj", "plan", "yolo", "--help"]).unwrap(), Action::Help);
+    assert_eq!(parse(["tj", "plan", "download", "--help"]).unwrap(), Action::Help);
+    assert_eq!(parse(["tj", "show", "opencode", "--help"]).unwrap(), Action::Help);
+    assert_eq!(parse(["tj", "use", "opencode", "--help"]).unwrap(), Action::Help);
+    assert_eq!(parse(["tj", "install", "opencode", "--help"]).unwrap(), Action::Help);
+    assert_eq!(parse(["tj", "security", "status", "--help"]).unwrap(), Action::Help);
+}
+#[rustfmt::skip]
+#[test] fn run_forwards_help_to_harness_when_not_at_position_1() {
+    assert_eq!(parse(["tj", "run", "codex", "--help"]).unwrap(), Action::Run(vec!["codex".into(), "--help".into()]));
+    assert_eq!(parse(["tj", "run", "codex", "-h"]).unwrap(), Action::Run(vec!["codex".into(), "-h".into()]));
+}
+#[rustfmt::skip]
+#[test] fn rejects_global_flag_with_subcommand() {
+    let err = parse(["tj", "-v", "version"]).unwrap_err();
+    assert!(err.contains("-v"));
+    let err = parse(["tj", "--version", "list"]).unwrap_err();
+    assert!(err.contains("--version"));
+    let err = parse(["tj", "--info", "show", "opencode"]).unwrap_err();
+    assert!(err.contains("--info"));
+}
+#[rustfmt::skip]
+#[test] fn run_help_without_harness_shows_help() {
+    assert_eq!(parse(["tj", "run", "--help"]).unwrap(), Action::Help);
+}


### PR DESCRIPTION
## v0.1.9

- Fixes `hlp()` helper to scan all arguments after the subcommand so `plan yolo --help`, `security status --help`, `show opencode --help`, etc. route to help text.
- Fixes global `-v`/`--version`/`--info` to reject an unexpected subcommand after the flag instead of silently discarding it.
- Fixes `npm postinstall` to exit 0 when a stale cargo binary shadows the npm shim on PATH.