### PR TITLE
release: v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.1.9] - 2026-07-07
+
+- Fixes `hlp()` helper to scan all arguments after the subcommand so `plan yolo --help`,
+  `security status --help`, `show opencode --help`, etc. route to help text. The `run`
+  subcommand still only checks position 1 so `run codex --help` forwards `--help` to
+  the harness as intended.
+- Fixes global `-v`/`--version`/`--info` to reject an unexpected subcommand after the
+  flag instead of silently discarding it: `terminal-jarvis -v version` and
+  `terminal-jarvis --info show opencode` now produce a clear error.
+- Fixes `npm postinstall` to exit 0 when a stale cargo binary shadows the npm shim on
+  PATH, so `npm install -g terminal-jarvis` no longer fails. The shadow warning is
+  still printed to stderr with actionable guidance.
+- Updates tests for all three bugfixes.
+
 ## [0.1.8] - 2026-07-07
 
 - Fixes `--help`/`-h` parsing on 12 of 14 subcommands so help text is reachable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "terminal-jarvis"
-version = "0.1.8"
+version = "0.1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-jarvis"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "A data-driven harness switcher for AI coding agents"
 authors = ["BA-CalderonMorales"]

--- a/npm/terminal-jarvis/package-lock.json
+++ b/npm/terminal-jarvis/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "terminal-jarvis",
   "version": "0.1.9",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {

--- a/npm/terminal-jarvis/package-lock.json
+++ b/npm/terminal-jarvis/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.1.8",
-  "lockfileVersion": 3,
+  "version": "0.1.9",
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "terminal-jarvis",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/npm/terminal-jarvis/package.json
+++ b/npm/terminal-jarvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Data-driven harness switcher for AI coding agents",
   "bin": {
     "terminal-jarvis": "bin/terminal-jarvis"

--- a/npm/terminal-jarvis/postinstall.js
+++ b/npm/terminal-jarvis/postinstall.js
@@ -2,4 +2,3 @@ const wrapper = require("./bin/terminal-jarvis");
 
 const status = wrapper.postinstallPathStatus();
 if (status.diagnostic) console.warn(status.diagnostic);
-if (status.kind === "shadow") process.exitCode = 1;

--- a/npm/terminal-jarvis/test-wrapper.js
+++ b/npm/terminal-jarvis/test-wrapper.js
@@ -110,7 +110,7 @@ test("path diagnostic reports stale binary before npm shim", () => {
   assert.match(diagnostic, /before the npm shim/);
 });
 
-test("global postinstall fails when PATH shadows the npm shim", () => {
+test("global postinstall warns on shadow but exits 0", () => {
   const root = tempDir();
   const prefix = path.join(root, "node");
   const stale = path.join(root, "cargo", "terminal-jarvis");
@@ -127,9 +127,10 @@ test("global postinstall fails when PATH shadows the npm shim", () => {
     },
     encoding: "utf8",
   });
-  assert.equal(result.status, 1);
+  assert.equal(result.status, 0);
   assert.ok(result.stderr.includes(stale));
   assert.ok(result.stderr.includes(shim));
+  assert.ok(result.stderr.includes("Remove or update"));
 });
 
 test("global postinstall path diagnostic supports explicit skip", () => {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -10,7 +10,6 @@ where I: IntoIterator, I::Item: Into<String>,
     if words.is_empty() { return Ok(Action::Help); }
     match words[0].as_str() {
         "help" | "--help" | "-h" => Ok(Action::Help),
-        "version" if hlp(&words) => Ok(Action::Help),
         "version" => version(&words[1..]),
         "--version" | "-v" if words.len() == 1 => Ok(Action::Version { verbose: false }),
         "--version" | "-v" => Err(format!("unexpected argument '{}' after --version/-v flag", words[1])),

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,7 +1,7 @@
 pub use super::action::Action;
 use crate::contracts::Capability;
 #[rustfmt::skip]
-fn hlp(words: &[String]) -> bool { words.get(1).is_some_and(|w| w == "--help" || w == "-h") }
+fn hlp(words: &[String]) -> bool { words.iter().skip(1).any(|w| w == "--help" || w == "-h") }
 #[rustfmt::skip]
 pub fn parse<I>(args: I) -> Result<Action, String>
 where I: IntoIterator, I::Item: Into<String>,
@@ -12,8 +12,10 @@ where I: IntoIterator, I::Item: Into<String>,
         "help" | "--help" | "-h" => Ok(Action::Help),
         "version" if hlp(&words) => Ok(Action::Help),
         "version" => version(&words[1..]),
-        "--version" | "-v" => Ok(Action::Version { verbose: false }),
-        "--info" => Ok(Action::Version { verbose: true }),
+        "--version" | "-v" if words.len() == 1 => Ok(Action::Version { verbose: false }),
+        "--version" | "-v" => Err(format!("unexpected argument '{}' after --version/-v flag", words[1])),
+        "--info" if words.len() == 1 => Ok(Action::Version { verbose: true }),
+        "--info" => Err(format!("unexpected argument '{}' after --info flag", words[1])),
         "list" | "tools" if hlp(&words) => Ok(Action::Help),
         "list" | "tools" => Ok(Action::List),
         "check" | "status" if hlp(&words) => Ok(Action::Help),
@@ -26,7 +28,7 @@ where I: IntoIterator, I::Item: Into<String>,
         "show" | "info" => one(&words, words[0].as_str()).map(Action::Show),
         "plan" if hlp(&words) => Ok(Action::Help),
         "plan" => plan(&words[1..]),
-        "run" if hlp(&words) => Ok(Action::Help),
+        "run" if words.get(1).is_some_and(|w| w == "--help" || w == "-h") => Ok(Action::Help),
         "run" => Ok(Action::Run(words[1..].to_vec())),
         "install" if hlp(&words) => Ok(Action::Help),
         "install" => one(&words, "install").map(Action::Install),

--- a/tests/cli_args_tests.rs
+++ b/tests/cli_args_tests.rs
@@ -51,3 +51,30 @@ use terminal_jarvis::contracts::Capability;
     assert!(error.contains("--bogus"));
     assert!(error.contains("usage"));
 }
+#[rustfmt::skip]
+#[test] fn help_in_any_position_after_subcommand() {
+    assert_eq!(parse(["tj", "plan", "yolo", "--help"]).unwrap(), Action::Help);
+    assert_eq!(parse(["tj", "plan", "download", "--help"]).unwrap(), Action::Help);
+    assert_eq!(parse(["tj", "show", "opencode", "--help"]).unwrap(), Action::Help);
+    assert_eq!(parse(["tj", "use", "opencode", "--help"]).unwrap(), Action::Help);
+    assert_eq!(parse(["tj", "install", "opencode", "--help"]).unwrap(), Action::Help);
+    assert_eq!(parse(["tj", "security", "status", "--help"]).unwrap(), Action::Help);
+}
+#[rustfmt::skip]
+#[test] fn run_forwards_help_to_harness_when_not_at_position_1() {
+    assert_eq!(parse(["tj", "run", "codex", "--help"]).unwrap(), Action::Run(vec!["codex".into(), "--help".into()]));
+    assert_eq!(parse(["tj", "run", "codex", "-h"]).unwrap(), Action::Run(vec!["codex".into(), "-h".into()]));
+}
+#[rustfmt::skip]
+#[test] fn rejects_global_flag_with_subcommand() {
+    let err = parse(["tj", "-v", "version"]).unwrap_err();
+    assert!(err.contains("-v"));
+    let err = parse(["tj", "--version", "list"]).unwrap_err();
+    assert!(err.contains("--version"));
+    let err = parse(["tj", "--info", "show", "opencode"]).unwrap_err();
+    assert!(err.contains("--info"));
+}
+#[rustfmt::skip]
+#[test] fn run_help_without_harness_shows_help() {
+    assert_eq!(parse(["tj", "run", "--help"]).unwrap(), Action::Help);
+}

--- a/tests/cli_version_tests.rs
+++ b/tests/cli_version_tests.rs
@@ -1,20 +1,12 @@
 use std::fs;
 use std::process::{Command, Output};
 
-fn tj(args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
-        .args(args)
-        .output()
-        .expect("terminal-jarvis runs")
-}
-
-fn stdout(output: &Output) -> String {
-    String::from_utf8_lossy(&output.stdout).to_string()
-}
-
-fn stderr(output: &Output) -> String {
-    String::from_utf8_lossy(&output.stderr).to_string()
-}
+#[rustfmt::skip]
+fn cmd(args: &[&str]) -> Output { Command::new(env!("CARGO_BIN_EXE_terminal-jarvis")).args(args).output().unwrap() }
+#[rustfmt::skip]
+fn so(o: &Output) -> String { String::from_utf8_lossy(&o.stdout).to_string() }
+#[rustfmt::skip]
+fn se(o: &Output) -> String { String::from_utf8_lossy(&o.stderr).to_string() }
 
 #[test]
 fn version_flags_do_not_require_catalog() {
@@ -27,14 +19,14 @@ fn version_flags_do_not_require_catalog() {
         .output()
         .expect("terminal-jarvis runs");
     assert!(output.status.success());
-    assert!(stdout(&output).starts_with("terminal-jarvis "));
+    assert!(so(&output).starts_with("terminal-jarvis "));
 }
 
 #[test]
 fn verbose_version_reports_provenance_paths() {
-    let output = tj(&["version", "--verbose"]);
-    assert!(output.status.success());
-    let body = stdout(&output);
+    let o = cmd(&["version", "--verbose"]);
+    assert!(o.status.success());
+    let body = so(&o);
     assert!(body.contains("binary:"));
     assert!(body.contains("release:"));
     assert!(body.contains("catalog:"));
@@ -50,7 +42,7 @@ fn verbose_version_ignores_empty_wrapper_env_values() {
         .output()
         .expect("terminal-jarvis runs");
     assert!(output.status.success());
-    let body = stdout(&output);
+    let body = so(&output);
     assert!(body.contains("distribution: unknown"));
     assert!(body.contains("release: https://github.com/BA-CalderonMorales"));
     assert!(body.contains("cache: unavailable"));
@@ -67,9 +59,22 @@ fn missing_catalog_error_names_catalog_path() {
         .output()
         .expect("terminal-jarvis runs");
     assert_eq!(output.status.code(), Some(2));
-    let error = stderr(&output);
+    let error = se(&output);
     assert!(error.contains("harness catalog is missing at"));
     assert!(error.contains("TERMINAL_JARVIS_CATALOG"));
+}
+
+#[test]
+#[rustfmt::skip]
+fn garbled_session_warns_on_stderr() {
+    let home = std::env::temp_dir().join(format!("tj-garbled-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&home);
+    fs::create_dir_all(&home).unwrap();
+    fs::write(home.join("session.toml"), "active_harness = \"codex\n").unwrap();
+    let o = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis")).arg("current").env("TERMINAL_JARVIS_HOME", &home).output().unwrap();
+    assert!(o.status.success());
+    assert!(se(&o).contains("warning"));
+    assert!(se(&o).contains("session.toml"));
 }
 
 #[test]
@@ -89,5 +94,5 @@ fn corrupt_session_error_reaches_stderr() {
         .expect("terminal-jarvis runs");
 
     assert_eq!(output.status.code(), Some(2));
-    assert!(stderr(&output).contains("stream did not contain valid UTF-8"));
+    assert!(se(&output).contains("stream did not contain valid UTF-8"));
 }

--- a/tests/cli_version_tests.rs
+++ b/tests/cli_version_tests.rs
@@ -1,98 +1,93 @@
 use std::fs;
 use std::process::{Command, Output};
-
 #[rustfmt::skip]
-fn cmd(args: &[&str]) -> Output { Command::new(env!("CARGO_BIN_EXE_terminal-jarvis")).args(args).output().unwrap() }
-#[rustfmt::skip]
-fn so(o: &Output) -> String { String::from_utf8_lossy(&o.stdout).to_string() }
+fn tj(args: &[&str]) -> Output { Command::new(env!("CARGO_BIN_EXE_terminal-jarvis")).args(args).output().expect("tj runs") }
 #[rustfmt::skip]
 fn se(o: &Output) -> String { String::from_utf8_lossy(&o.stderr).to_string() }
+#[rustfmt::skip]
+fn home(name: &str) -> std::path::PathBuf { let h = std::env::temp_dir().join(format!("{}-{}", name, std::process::id())); let _ = fs::remove_dir_all(&h); fs::create_dir_all(&h).unwrap(); h }
+#[rustfmt::skip]
+fn nocat() -> String { let p = std::env::temp_dir().join(format!("tj-nocat-{}", std::process::id())); p.to_string_lossy().to_string() }
 
 #[test]
 fn version_flags_do_not_require_catalog() {
-    let output = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+    let o = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
         .arg("--version")
-        .env(
-            "TERMINAL_JARVIS_CATALOG",
-            "/tmp/terminal-jarvis-missing-catalog",
-        )
+        .env("TERMINAL_JARVIS_CATALOG", nocat())
         .output()
-        .expect("terminal-jarvis runs");
-    assert!(output.status.success());
-    assert!(so(&output).starts_with("terminal-jarvis "));
+        .unwrap();
+    assert!(
+        o.status.success() && String::from_utf8_lossy(&o.stdout).starts_with("terminal-jarvis ")
+    );
 }
-
 #[test]
 fn verbose_version_reports_provenance_paths() {
-    let o = cmd(&["version", "--verbose"]);
+    let o = tj(&["version", "--verbose"]);
     assert!(o.status.success());
-    let body = so(&o);
-    assert!(body.contains("binary:"));
-    assert!(body.contains("release:"));
-    assert!(body.contains("catalog:"));
+    let b = String::from_utf8_lossy(&o.stdout);
+    assert!(b.contains("binary:") && b.contains("release:") && b.contains("catalog:"));
 }
-
 #[test]
 fn verbose_version_ignores_empty_wrapper_env_values() {
-    let output = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+    let o = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
         .args(["version", "--verbose"])
         .env("TERMINAL_JARVIS_DISTRIBUTION", "")
         .env("TERMINAL_JARVIS_RELEASE_URL", "")
         .env("TERMINAL_JARVIS_CACHE", "")
         .output()
-        .expect("terminal-jarvis runs");
-    assert!(output.status.success());
-    let body = so(&output);
-    assert!(body.contains("distribution: unknown"));
-    assert!(body.contains("release: https://github.com/BA-CalderonMorales"));
-    assert!(body.contains("cache: unavailable"));
+        .unwrap();
+    assert!(o.status.success());
+    let b = String::from_utf8_lossy(&o.stdout);
+    assert!(
+        b.contains("distribution: unknown")
+            && b.contains("release: https://github.com")
+            && b.contains("cache: unavailable")
+    );
 }
-
 #[test]
 fn missing_catalog_error_names_catalog_path() {
-    let output = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+    let o = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
         .arg("list")
-        .env(
-            "TERMINAL_JARVIS_CATALOG",
-            "/tmp/terminal-jarvis-missing-catalog",
-        )
+        .env("TERMINAL_JARVIS_CATALOG", nocat())
         .output()
-        .expect("terminal-jarvis runs");
-    assert_eq!(output.status.code(), Some(2));
-    let error = se(&output);
-    assert!(error.contains("harness catalog is missing at"));
-    assert!(error.contains("TERMINAL_JARVIS_CATALOG"));
+        .unwrap();
+    assert_eq!(o.status.code(), Some(2));
+    assert!(
+        se(&o).contains("harness catalog is missing at")
+            && se(&o).contains("TERMINAL_JARVIS_CATALOG")
+    );
 }
-
 #[test]
-#[rustfmt::skip]
-fn garbled_session_warns_on_stderr() {
-    let home = std::env::temp_dir().join(format!("tj-garbled-{}", std::process::id()));
-    let _ = fs::remove_dir_all(&home);
-    fs::create_dir_all(&home).unwrap();
-    fs::write(home.join("session.toml"), "active_harness = \"codex\n").unwrap();
-    let o = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis")).arg("current").env("TERMINAL_JARVIS_HOME", &home).output().unwrap();
-    assert!(o.status.success());
-    assert!(se(&o).contains("warning"));
-    assert!(se(&o).contains("session.toml"));
+fn valid_session_skips_warning() {
+    let h = home("tj-v");
+    fs::write(h.join("session.toml"), "active_harness = \"codex\"").unwrap();
+    let o = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+        .arg("current")
+        .env("TERMINAL_JARVIS_HOME", &h)
+        .output()
+        .unwrap();
+    assert!(o.status.success() && !se(&o).contains("session.toml could not be parsed"));
 }
-
+#[test]
+fn garbled_session_warns_on_stderr() {
+    let h = home("tj-g");
+    fs::write(h.join("session.toml"), "active_harness = \"codex\n").unwrap();
+    let o = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+        .arg("current")
+        .env("TERMINAL_JARVIS_HOME", &h)
+        .output()
+        .unwrap();
+    assert!(o.status.success() && se(&o).contains("session.toml could not be parsed"));
+}
 #[test]
 fn corrupt_session_error_reaches_stderr() {
-    let home = std::env::temp_dir().join(format!(
-        "terminal-jarvis-corrupt-session-{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&home);
-    fs::create_dir_all(&home).unwrap();
-    fs::write(home.join("session.toml"), [0xff_u8]).unwrap();
-
-    let output = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
+    let h = home("tj-c");
+    fs::write(h.join("session.toml"), [0xff_u8]).unwrap();
+    let o = Command::new(env!("CARGO_BIN_EXE_terminal-jarvis"))
         .arg("current")
-        .env("TERMINAL_JARVIS_HOME", home)
+        .env("TERMINAL_JARVIS_HOME", h)
         .output()
-        .expect("terminal-jarvis runs");
-
-    assert_eq!(output.status.code(), Some(2));
-    assert!(se(&output).contains("stream did not contain valid UTF-8"));
+        .unwrap();
+    assert_eq!(o.status.code(), Some(2));
+    assert!(se(&o).contains("stream did not contain valid UTF-8"));
 }


### PR DESCRIPTION
## v0.1.9

- Fixes `hlp()` helper to scan all arguments after the subcommand so `plan yolo --help`, `security status --help`, `show opencode --help`, etc. route to help text.
- Fixes global `-v`/`--version`/`--info` to reject an unexpected subcommand after the flag instead of silently discarding it.
- Fixes `npm postinstall` to exit 0 when a stale cargo binary shadows the npm shim on PATH.
- Fixes mutation survivors: removes redundant hlp() guard on version, adds test for session warning.