### PR TITLE
fix: restore package-lock.json lockfileVersion to 3

### DIFF
--- a/npm/terminal-jarvis/package-lock.json
+++ b/npm/terminal-jarvis/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "terminal-jarvis",
   "version": "0.1.9",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {


### PR DESCRIPTION
Restores lockfileVersion from 2 to 3 to match what npm on node >=20 produces. Prevents persistent lockfile churn and merge conflicts when developers/CI run npm install.