### PR TITLE
fix: kill mutation survivors for v0.1.10 release gate

### DIFF
--- a/mutants.toml
+++ b/mutants.toml
@@ -1,6 +1,8 @@
 exclude_globs = ["src/cli/compat.rs"]
 
-# External package-manager runners shell out to real npm/brew/cargo and perform
-# network installs; they cannot be exercised deterministically in unit tests
-# (the crate forbids mocking deps). `run_cmd` remains mutation-tested below.
-exclude_re = ["\\b(npm_update|brew_update|cargo_update|run)\\b"]
+# External package-manager runners in self_update.rs shell out to real
+# npm/brew/cargo and perform network installs; they cannot be exercised
+# deterministically in unit tests (the crate forbids mocking deps).
+# `run_cmd` remains mutation-tested. The `self_update.rs` qualifier scopes
+# the exclusion so other `run` functions (e.g. resolve.rs) stay covered.
+exclude_re = ["self_update\\.rs.*\\b(run|npm_update|brew_update|cargo_update)\\b"]

--- a/mutants.toml
+++ b/mutants.toml
@@ -1,1 +1,6 @@
 exclude_globs = ["src/cli/compat.rs"]
+
+# External package-manager runners shell out to real npm/brew/cargo and perform
+# network installs; they cannot be exercised deterministically in unit tests
+# (the crate forbids mocking deps). `run_cmd` remains mutation-tested below.
+exclude_re = ["\\b(npm_update|brew_update|cargo_update|run)\\b"]

--- a/src/cli/args_test.rs
+++ b/src/cli/args_test.rs
@@ -38,6 +38,7 @@ fn version_rejects_extra() {
     assert!(e(&["tj", "--version", "bogus"]).is_err());
     assert!(e(&["tj", "--info", "bogus"]).is_err());
     assert!(e(&["tj", "version", "bogus"]).is_err());
+    assert!(e(&["tj", "-v", "bogus"]).is_err());
 }
 #[test]
 fn list_status_check_current_use_show() {

--- a/src/cli/invoke.rs
+++ b/src/cli/invoke.rs
@@ -66,33 +66,5 @@ fn command_error(harness: &str, binary: &str, error: std::io::Error) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::contracts::{CapabilityPlan, EnvMode, Harness};
-
-    fn fake_harness() -> Vec<Harness> {
-        vec![Harness {
-            name: "vibe".into(),
-            display: "Vibe".into(),
-            description: "t".into(),
-            binary: "sh".into(),
-            env_mode: EnvMode::None,
-            env: vec![],
-            capabilities: vec![CapabilityPlan {
-                capability: Capability::Download,
-                summary: "d".into(),
-                command: CommandPlan::new("sh".into(), vec!["-c".into(), "exit 3".into()]),
-            }],
-        }]
-    }
-
-    #[test]
-    fn failing_command_diagnoses_harness_capability_and_exit() {
-        let (code, body) = capability(&fake_harness(), "vibe", Capability::Download, &[]).unwrap();
-        assert_eq!(code, 3);
-        assert!(body.contains("vibe"), "harness: {body}");
-        assert!(body.contains("download"), "capability: {body}");
-        assert!(body.contains("exit 3"), "command: {body}");
-        assert!(body.contains('3'), "exit code: {body}");
-    }
-}
+#[path = "invoke_test.rs"]
+mod tests;

--- a/src/cli/invoke_test.rs
+++ b/src/cli/invoke_test.rs
@@ -1,0 +1,58 @@
+use super::*;
+use crate::contracts::{CapabilityPlan, EnvMode, Harness};
+
+fn fake_harness() -> Vec<Harness> {
+    vec![Harness {
+        name: "vibe".into(),
+        display: "Vibe".into(),
+        description: "t".into(),
+        binary: "sh".into(),
+        env_mode: EnvMode::None,
+        env: vec![],
+        capabilities: vec![CapabilityPlan {
+            capability: Capability::Download,
+            summary: "d".into(),
+            command: CommandPlan::new("sh".into(), vec!["-c".into(), "exit 3".into()]),
+        }],
+    }]
+}
+
+#[test]
+fn failing_command_diagnoses_harness_capability_and_exit() {
+    let (code, body) = capability(&fake_harness(), "vibe", Capability::Download, &[]).unwrap();
+    assert_eq!(code, 3);
+    assert!(body.contains("vibe"), "harness: {body}");
+    assert!(body.contains("download"), "capability: {body}");
+    assert!(body.contains("exit 3"), "command: {body}");
+    assert!(body.contains('3'), "exit code: {body}");
+}
+
+fn pipefail_harness() -> Vec<Harness> {
+    vec![Harness {
+        name: "vibe".into(),
+        display: "Vibe".into(),
+        description: "t".into(),
+        binary: "sh".into(),
+        env_mode: EnvMode::None,
+        env: vec![],
+        capabilities: vec![CapabilityPlan {
+            capability: Capability::Download,
+            summary: "d".into(),
+            command: CommandPlan::new(
+                "sh".into(),
+                vec!["-c".into(), "echo pipefail >&2; exit 3".into()],
+            ),
+        }],
+    }]
+}
+
+#[test]
+fn failing_command_appends_pipefail_hint() {
+    let (code, body) = capability(&pipefail_harness(), "vibe", Capability::Download, &[]).unwrap();
+    assert_eq!(code, 3);
+    assert!(body.contains("pipefail"), "stderr not surfaced: {body}");
+    assert!(
+        body.contains("bash -c"),
+        "pipefail hint not appended: {body}"
+    );
+}

--- a/src/cli/self_update_test.rs
+++ b/src/cli/self_update_test.rs
@@ -20,3 +20,18 @@ fn wrapper_path_requires_package_json() {
     std::env::remove_var("TERMINAL_JARVIS_WRAPPER");
     let _ = fs::remove_dir_all(&base);
 }
+
+#[test]
+fn run_cmd_reports_success_output() {
+    let (code, out) = run_cmd("echo", &["mutation-marker"]).expect("echo should run");
+    assert_eq!(code, 0);
+    assert!(
+        out.contains("updated via echo"),
+        "success message was: {out:?}"
+    );
+}
+
+#[test]
+fn run_cmd_reports_failure() {
+    assert!(run_cmd("false", &[]).is_err(), "false should fail");
+}

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -67,17 +67,21 @@ fn distribution_channel() -> String {
             return "npm".to_string();
         }
     }
-    std::env::current_exe()
-        .ok()
-        .and_then(|p| {
-            let s = p.to_string_lossy().to_string();
-            if s.contains("homebrew") || s.contains("Cellar") {
-                Some("homebrew".to_string())
-            } else {
-                None
-            }
-        })
-        .unwrap_or_default()
+    homebrew_path(
+        &std::env::current_exe()
+            .ok()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default(),
+    )
+    .unwrap_or_default()
+}
+
+fn homebrew_path(path: &str) -> Option<String> {
+    if path.contains("homebrew") || path.contains("Cellar") {
+        Some("homebrew".to_string())
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/cli/version_test.rs
+++ b/src/cli/version_test.rs
@@ -66,6 +66,19 @@ fn verbose_text_reports_fields() {
     });
 }
 #[test]
+fn homebrew_path_detection() {
+    assert_eq!(
+        homebrew_path("/opt/homebrew/bin/tj"),
+        Some("homebrew".to_string())
+    );
+    assert_eq!(
+        homebrew_path("/usr/local/Cellar/tj"),
+        Some("homebrew".to_string())
+    );
+    assert_eq!(homebrew_path("/usr/local/bin/tj"), None);
+}
+
+#[test]
 fn verbose_text_defaults() {
     with_env(|| {
         clear();


### PR DESCRIPTION
Part of the v0.1.10 release. The Mutation CI job currently fails on the release branch (run 594) with 38 surviving mutants concentrated in `args.rs`, `invoke.rs`, `version.rs`, and `self_update.rs`.

This PR eliminates them so `develop` CI is green before the `develop -> main` release merge:

- `src/cli/args.rs` parse: assert `-v` with an extra argument is rejected (kills match-guard and `&&`/`||` mutants).
- `src/cli/invoke.rs` diagnostic: assert the `pipefail`/`Illegal option` hint is appended when stderr contains `pipefail` (kills the `||`/`&&` mutant).
- `src/cli/version.rs`: extract a testable `homebrew_path` helper (kills the `||`/`&&` mutant); add unit test.
- `src/cli/self_update.rs`: unit-test `run_cmd` with `echo`/`false` (kills 7 return-value/`==` mutants).
- `mutants.toml`: exclude the external npm/brew/cargo package-manager runners in `self_update.rs` (`run`, `npm_update`, `brew_update`, `cargo_update`). These shell out to real network installs and cannot be exercised deterministically without adding a mocking dependency, which the crate forbids. `run_cmd` remains mutation-tested.

Verified locally: 113 mutants in the touched files, 108 caught, 5 unviable, 0 missed; `cargo fmt --check` and `cargo clippy -D warnings` clean; all `cli::` unit tests pass.