### PR TITLE
release: v0.1.11

### DIFF
--- a/.github/workflows/cd-multiplatform.yml
+++ b/.github/workflows/cd-multiplatform.yml
@@ -55,22 +55,36 @@ jobs:
     needs: release-meta
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux-x64-gnu
             os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - platform: linux-arm64-gnu
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
           - platform: macos-x64
             os: macos-15-intel
+            target: x86_64-apple-darwin
           - platform: macos-arm64
             os: macos-15
+            target: aarch64-apple-darwin
+          - platform: win32-x64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.release-meta.outputs.tag }}
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
       - uses: actions/setup-node@v6
         with:
@@ -84,10 +98,12 @@ jobs:
             ~/.cargo/git
             ~/.cargo/registry
             target
-          key: cargo-cd-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-v1
-          restore-keys: cargo-cd-${{ runner.os }}-
+          key: cargo-cd-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-v1
+          restore-keys: cargo-cd-${{ runner.os }}-${{ matrix.target }}-
 
       - name: Build package
+        env:
+          CARGO_BUILD_TARGET: ${{ matrix.target }}
         run: scripts/package-release.sh
 
       - name: Verify platform package shape
@@ -234,6 +250,7 @@ jobs:
           }
           repo="https://github.com/${GITHUB_REPOSITORY}"
           linux_x64_sha="$(sha_for linux-x64-gnu)"
+          linux_arm64_sha="$(sha_for linux-arm64-gnu)"
           macos_x64_sha="$(sha_for macos-x64)"
           macos_arm64_sha="$(sha_for macos-arm64)"
           cat > ../tap/Formula/terminal-jarvis.rb <<EOF
@@ -257,6 +274,9 @@ jobs:
               if Hardware::CPU.intel?
                 url "$repo/releases/download/$TAG/terminal-jarvis-$VERSION-linux-x64-gnu.tar.gz"
                 sha256 "$linux_x64_sha"
+              elsif Hardware::CPU.arm?
+                url "$repo/releases/download/$TAG/terminal-jarvis-$VERSION-linux-arm64-gnu.tar.gz"
+                sha256 "$linux_arm64_sha"
               end
             end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.11] - 2026-07-09
+
+- Adds real multi-platform release packaging for Linux x64, Linux ARM64,
+  macOS Intel, macOS ARM64, and Windows x64 GitHub Release assets.
+- Adds native Windows npm launcher support through the `win32-x64` release
+  asset and validates cached Windows PE binaries.
+- Makes global npm install fail when an older `terminal-jarvis` earlier on
+  `PATH` would keep `terminal-jarvis@latest` from being the command users run.
+- Lowers the npm wrapper engine requirement to Node `>=18.17`, matching the
+  runtime surface used by the wrapper.
+
 ## [0.1.10] - 2026-07-08
 
 - Fixes `-v version` to delegate to the `version` subcommand instead of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "terminal-jarvis"
-version = "0.1.10"
+version = "0.1.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-jarvis"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "A data-driven harness switcher for AI coding agents"
 authors = ["BA-CalderonMorales"]

--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ a Node launcher that downloads the matching Terminal Jarvis GitHub Release
 asset, verifies its `.sha256` file, caches it, and then executes it. Homebrew is
 the binary installer path and installs the platform release archive from the tap.
 
-Supported prebuilt assets are `linux-x64-gnu`, `macos-x64`, and `macos-arm64`.
-Native Windows npm installs are not published yet; use WSL on Windows.
+Supported prebuilt assets are `linux-x64-gnu`, `linux-arm64-gnu`,
+`macos-x64`, `macos-arm64`, and `win32-x64`. Native Windows npm installs use
+the `win32-x64` GitHub Release asset and work from Command Prompt, PowerShell,
+or Git Bash when the npm shim is first on `PATH`.
 
 ## Quick Start
 

--- a/docs/distribution-hardening.md
+++ b/docs/distribution-hardening.md
@@ -65,7 +65,13 @@ The launcher must fail closed when:
 - the platform has no supported release asset;
 - the release archive or checksum is missing;
 - the downloaded checksum does not match;
-- the cache path is not executable after extraction.
+- the cached native binary is missing, invalid, or not executable after
+  extraction on platforms that expose executable bits.
+
+Global npm installs must also fail closed when the installed npm shim would be
+shadowed by an older `terminal-jarvis` earlier on `PATH`; otherwise
+`npm install -g terminal-jarvis@latest` can appear successful while the next
+`terminal-jarvis --version` still executes an older Cargo or manual install.
 
 ## Release Split
 

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -37,7 +37,8 @@ scripts/local-cd.sh --check-auth
 ```
 
 Tagged releases (`v*`) trigger `.github/workflows/cd-multiplatform.yml`:
-crate publish, GitHub release assets, Homebrew tap update, and npm package.
+crate publish, Linux/macOS/Windows GitHub release assets, Homebrew tap update,
+and npm package.
 
 See [release-plan.md](release-plan.md) for the checklist and auth boundaries.
 

--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -60,11 +60,13 @@ a binary archive with bundled harness data, a SHA-256 file, an npm package
 staging directory, and a versioned Homebrew formula that points at the release
 archive URL. npm staging must not embed `bin/terminal-jarvis-bin`; the npm
 launcher resolves prebuilt binaries from GitHub Releases with checksum
-verification. Platform names are user-facing labels such as `linux-x64-gnu` or
-`macos-arm64`; the Rust target triple remains visible in
+verification. Platform names are user-facing labels such as `linux-x64-gnu`,
+`linux-arm64-gnu`, `macos-arm64`, or `win32-x64`; the Rust target triple remains visible in
 `scripts/package-release.sh --check`. Packaging also runs
 `scripts/integration-hardening.sh` against the staged binary, bundled harnesses,
-npm wrapper, and generated Homebrew formula before reporting artifact paths.
+npm wrapper, and generated Homebrew formula before reporting artifact paths
+when the target can run on the host. Cross-target packages still verify archive
+shape, checksum, npm payload shape, and formula syntax.
 
 `scripts/local-cd.sh` collects the same archive and checksum files into a
 `release-assets/v<version>/` directory and verifies every checksum and recorded
@@ -101,11 +103,12 @@ Before publishing a `v0.1.x` release:
 
 The root GitHub workflows keep the tag-push release shape. CI verifies the lean
 Rust crate, catalog contracts, package metadata, security gates, npm wrapper,
-Homebrew syntax, coverage, and mutation. Multi-platform CD builds host archives
-for Linux and macOS, runs integration hardening before publish jobs can proceed,
-publishes the crates.io package when needed, publishes the GitHub release
-assets, updates the Homebrew tap, and publishes or retags the npm package with
-`latest`, `stable`, and `beta` pointing at the same patch version.
+Homebrew syntax, coverage, and mutation. Multi-platform CD builds release
+archives for Linux x64, Linux ARM64, macOS Intel, macOS ARM64, and Windows x64;
+runs integration hardening before publish jobs can proceed for host-executable
+targets; publishes the crates.io package when needed; publishes the GitHub
+release assets; updates the Homebrew tap; and publishes or retags the npm
+package with `latest`, `stable`, and `beta` pointing at the same patch version.
 
 Terminal Jarvis release validation should not automatically download arbitrary
 harness dependencies. Docker coverage should start as documented baseline images

--- a/npm/terminal-jarvis/README.md
+++ b/npm/terminal-jarvis/README.md
@@ -7,9 +7,9 @@ The package does not include a native binary. Installed npm copies use
 Jarvis archive from GitHub Releases, verify the release `.sha256` checksum,
 cache the unpacked release, and execute it.
 
-Supported npm release assets are `linux-x64-gnu`, `macos-x64`, and
-`macos-arm64`. Native Windows installs through Git Bash or cmd are not
-supported until CI publishes a `win32-x64` asset; use WSL on Windows.
+Supported npm release assets are `linux-x64-gnu`, `linux-arm64-gnu`,
+`macos-x64`, `macos-arm64`, and `win32-x64`. Native Windows installs through
+Command Prompt, PowerShell, and Git Bash use the `win32-x64` asset.
 
 The wrapper guidance shipped at `bin/README.txt` is included in the npm package
 so installed copies can explain the package behavior without relying on the
@@ -18,8 +18,8 @@ source checkout.
 In source checkouts it delegates to:
 
 1. `TERMINAL_JARVIS_BIN`
-2. `target/release/terminal-jarvis`
-3. `target/debug/terminal-jarvis`
+2. `target/release/terminal-jarvis` or `target/release/terminal-jarvis.exe`
+3. `target/debug/terminal-jarvis` or `target/debug/terminal-jarvis.exe`
 4. `cargo run --` from the repository root
 
 Use `TERMINAL_JARVIS_CACHE` to choose the cache directory. Set

--- a/npm/terminal-jarvis/bin/README.txt
+++ b/npm/terminal-jarvis/bin/README.txt
@@ -13,11 +13,15 @@ What it does:
 
 Supported downloaded assets:
 - linux-x64-gnu
+- linux-arm64-gnu
 - macos-x64
 - macos-arm64
+- win32-x64
 
-Native Windows npm installs are not supported until a win32-x64 release asset is
-published. Use WSL on Windows.
+Native Windows npm installs use the win32-x64 asset from Command Prompt,
+PowerShell, or Git Bash. If npm reports a stale terminal-jarvis binary earlier
+on PATH, remove that binary or move the npm prefix earlier in PATH before
+retrying the install.
 
 Useful environment variables:
 - TERMINAL_JARVIS_BIN: execute a specific local binary instead of downloading.

--- a/npm/terminal-jarvis/bin/terminal-jarvis
+++ b/npm/terminal-jarvis/bin/terminal-jarvis
@@ -62,9 +62,10 @@ function explicit(binary, source, catalog = "") {
 
 function sourceCandidates() {
   const catalog = path.resolve(repo, "harnesses");
+  const binary = executableName();
   return [
-    { binary: path.resolve(repo, "target/release/terminal-jarvis"), catalog },
-    { binary: path.resolve(repo, "target/debug/terminal-jarvis"), catalog },
+    { binary: path.resolve(repo, "target/release", binary), catalog },
+    { binary: path.resolve(repo, "target/debug", binary), catalog },
   ];
 }
 
@@ -77,7 +78,7 @@ async function downloadRelease() {
   const cache = cacheRoot();
   const root = path.join(cache, pkg.version, platform);
   const unpacked = path.join(root, `${pkg.name}-${pkg.version}-${platform}`);
-  const binary = path.join(unpacked, "bin", "terminal-jarvis");
+  const binary = path.join(unpacked, "bin", executableName());
   const catalog = path.join(unpacked, "harnesses");
   if (cachedReleaseUsable(binary, catalog)) {
     fs.chmodSync(binary, 0o755);
@@ -128,8 +129,10 @@ function cachedBinaryUsable(binary) {
 }
 
 function hasNativeBinaryMagic(header) {
-  return ["7f454c46", "cffaedfe", "cefaedfe", "feedfacf", "feedface", "cafebabe"]
-    .includes(header.toString("hex"));
+  const hex = header.toString("hex");
+  return hex.startsWith("4d5a") ||
+    ["7f454c46", "cffaedfe", "cefaedfe", "feedfacf", "feedface", "cafebabe"]
+      .includes(hex);
 }
 
 function downloadFailure(releaseUrl, error) {
@@ -146,17 +149,23 @@ function platformName() {
 
 function platformNameFor(platform, arch) {
   if (platform === "linux" && arch === "x64") return "linux-x64-gnu";
+  if (platform === "linux" && arch === "arm64") return "linux-arm64-gnu";
   if (platform === "darwin" && arch === "x64") return "macos-x64";
   if (platform === "darwin" && arch === "arm64") return "macos-arm64";
+  if (platform === "win32" && arch === "x64") return "win32-x64";
   throw new Error(unsupportedPlatformMessage(platform, arch));
 }
 
 function unsupportedPlatformMessage(platform, arch) {
   const current = `${platform}-${arch}`;
   return `unsupported platform: ${current}. ` +
-    "The npm package downloads GitHub Release assets for linux-x64-gnu, macos-x64, and macos-arm64. " +
-    "Native Windows npm installs are not supported until a win32-x64 asset is built in CI; use WSL on Windows. " +
+    "The npm package downloads GitHub Release assets for linux-x64-gnu, linux-arm64-gnu, " +
+    "macos-x64, macos-arm64, and win32-x64. " +
     guidanceHint();
+}
+
+function executableName(platform = process.platform) {
+  return platform === "win32" ? "terminal-jarvis.exe" : "terminal-jarvis";
 }
 
 function guidanceHint() {
@@ -303,6 +312,7 @@ module.exports = {
   cachedReleaseUsable,
   childEnv,
   downloadFailure,
+  executableName,
   guidanceHint,
   pathShadowDiagnostic,
   platformNameFor,

--- a/npm/terminal-jarvis/package-lock.json
+++ b/npm/terminal-jarvis/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terminal-jarvis",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
         "terminal-jarvis": "bin/terminal-jarvis"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18.17"
       }
     }
   }

--- a/npm/terminal-jarvis/package.json
+++ b/npm/terminal-jarvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-jarvis",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Data-driven harness switcher for AI coding agents",
   "bin": {
     "terminal-jarvis": "bin/terminal-jarvis"
@@ -30,6 +30,6 @@
     "url": "git+https://github.com/BA-CalderonMorales/terminal-jarvis.git"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18.17"
   }
 }

--- a/npm/terminal-jarvis/postinstall.js
+++ b/npm/terminal-jarvis/postinstall.js
@@ -8,7 +8,7 @@ if (status.diagnostic) {
 if (status.kind === "shadow") {
   console.error(
     "terminal-jarvis: refusing to complete a global install because " +
-    "terminal-jarvis@latest would not be the command resolved on PATH. " +
+    "the installed npm package would not be the command resolved on PATH. " +
     "Move the npm prefix earlier in PATH, remove the stale binary, or set " +
     "TERMINAL_JARVIS_SKIP_PATH_DIAGNOSTIC=1 to bypass this check."
   );

--- a/npm/terminal-jarvis/postinstall.js
+++ b/npm/terminal-jarvis/postinstall.js
@@ -1,4 +1,16 @@
 const wrapper = require("./bin/terminal-jarvis");
 
 const status = wrapper.postinstallPathStatus();
-if (status.diagnostic) console.warn(status.diagnostic);
+if (status.diagnostic) {
+  const write = status.kind === "shadow" ? console.error : console.warn;
+  write(status.diagnostic);
+}
+if (status.kind === "shadow") {
+  console.error(
+    "terminal-jarvis: refusing to complete a global install because " +
+    "terminal-jarvis@latest would not be the command resolved on PATH. " +
+    "Move the npm prefix earlier in PATH, remove the stale binary, or set " +
+    "TERMINAL_JARVIS_SKIP_PATH_DIAGNOSTIC=1 to bypass this check."
+  );
+  process.exit(1);
+}

--- a/npm/terminal-jarvis/test-wrapper.js
+++ b/npm/terminal-jarvis/test-wrapper.js
@@ -23,6 +23,13 @@ test("cached binary validation rejects text files", () => {
   assert.equal(wrapper.cachedBinaryUsable(file), false);
 });
 
+test("cached binary validation accepts Windows PE files", () => {
+  const file = path.join(tempDir(), "terminal-jarvis.exe");
+  fs.writeFileSync(file, Buffer.from([0x4d, 0x5a, 0x90, 0x00]));
+  fs.chmodSync(file, 0o755);
+  assert.equal(wrapper.cachedBinaryUsable(file), true);
+});
+
 test("cached release validation requires binary and catalog", () => {
   const root = tempDir();
   const binary = path.join(root, "bin", "terminal-jarvis");
@@ -59,14 +66,22 @@ test("download errors name the release URL and override knob", () => {
 
 test("platform mapping names published release assets", () => {
   assert.equal(wrapper.platformNameFor("linux", "x64"), "linux-x64-gnu");
+  assert.equal(wrapper.platformNameFor("linux", "arm64"), "linux-arm64-gnu");
   assert.equal(wrapper.platformNameFor("darwin", "x64"), "macos-x64");
   assert.equal(wrapper.platformNameFor("darwin", "arm64"), "macos-arm64");
+  assert.equal(wrapper.platformNameFor("win32", "x64"), "win32-x64");
 });
 
-test("unsupported platform text gives Windows install guidance", () => {
+test("executable name matches host conventions", () => {
+  assert.equal(wrapper.executableName("linux"), "terminal-jarvis");
+  assert.equal(wrapper.executableName("darwin"), "terminal-jarvis");
+  assert.equal(wrapper.executableName("win32"), "terminal-jarvis.exe");
+});
+
+test("unsupported platform text names supported release assets", () => {
   assert.throws(
-    () => wrapper.platformNameFor("win32", "x64"),
-    /Native Windows npm installs are not supported.*use WSL on Windows.*README\.txt/
+    () => wrapper.platformNameFor("freebsd", "x64"),
+    /linux-x64-gnu.*linux-arm64-gnu.*macos-x64.*macos-arm64.*win32-x64.*README\.txt/
   );
 });
 
@@ -110,7 +125,7 @@ test("path diagnostic reports stale binary before npm shim", () => {
   assert.match(diagnostic, /before the npm shim/);
 });
 
-test("global postinstall warns on shadow but exits 0", () => {
+test("global postinstall fails when stale binary shadows npm shim", () => {
   const root = tempDir();
   const prefix = path.join(root, "node");
   const stale = path.join(root, "cargo", "terminal-jarvis");
@@ -127,10 +142,10 @@ test("global postinstall warns on shadow but exits 0", () => {
     },
     encoding: "utf8",
   });
-  assert.equal(result.status, 0);
+  assert.equal(result.status, 1);
   assert.ok(result.stderr.includes(stale));
   assert.ok(result.stderr.includes(shim));
-  assert.ok(result.stderr.includes("Remove or update"));
+  assert.ok(result.stderr.includes("refusing to complete a global install"));
 });
 
 test("global postinstall path diagnostic supports explicit skip", () => {

--- a/npm/terminal-jarvis/test-wrapper.js
+++ b/npm/terminal-jarvis/test-wrapper.js
@@ -146,6 +146,7 @@ test("global postinstall fails when stale binary shadows npm shim", () => {
   assert.ok(result.stderr.includes(stale));
   assert.ok(result.stderr.includes(shim));
   assert.ok(result.stderr.includes("refusing to complete a global install"));
+  assert.ok(!result.stderr.includes("@latest"));
 });
 
 test("global postinstall path diagnostic supports explicit skip", () => {

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -110,7 +110,7 @@ class TerminalJarvis < Formula
   license "MIT"
 
   def install
-    bin.install "bin/terminal-jarvis"
+    bin.install "bin/$binary_name" => "$name"
     pkgshare.install "harnesses"
   end
 

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -26,7 +26,13 @@ sha256_file() {
 name=$(value_from_cargo name)
 repo=$(value_from_cargo repository)
 version=$(value_from_cargo version)
-target=$(rustc -vV | sed -n 's/^host: //p')
+host_target=$(rustc -vV | sed -n 's/^host: //p')
+target=${CARGO_BUILD_TARGET:-${TARGET:-}}
+target_explicit=1
+if test -z "$target"; then
+  target=$host_target
+  target_explicit=0
+fi
 case "$target" in
   x86_64-unknown-linux-gnu) platform=linux-x64-gnu ;;
   aarch64-unknown-linux-gnu) platform=linux-arm64-gnu ;;
@@ -34,14 +40,20 @@ case "$target" in
   aarch64-unknown-linux-musl) platform=linux-arm64-musl ;;
   x86_64-apple-darwin) platform=macos-x64 ;;
   aarch64-apple-darwin) platform=macos-arm64 ;;
+  x86_64-pc-windows-msvc) platform=win32-x64 ;;
   *) platform=$target ;;
 esac
 archive=$name-$version-$platform.tar.gz
+binary_name=$name
+case "$target" in
+  *-pc-windows-*) binary_name=$name.exe ;;
+esac
 
 test -n "$name" || fail "Cargo.toml name missing"
 test -n "$repo" || fail "Cargo.toml repository missing"
 test -n "$version" || fail "Cargo.toml version missing"
-test -n "$target" || fail "rustc host target missing"
+test -n "$host_target" || fail "rustc host target missing"
+test -n "$target" || fail "rustc build target missing"
 test -d harnesses || fail "harnesses directory missing"
 test -x npm/terminal-jarvis/bin/terminal-jarvis || fail "npm wrapper missing"
 
@@ -58,7 +70,13 @@ fi
 test "$mode" = "build" || fail "usage: scripts/package-release.sh [--check|build] [out-dir]"
 
 git_sha=$(git rev-parse HEAD 2>/dev/null || echo unknown)
-TERMINAL_JARVIS_GIT_SHA=$git_sha cargo build --release --locked
+if test "$target_explicit" = "1"; then
+  TERMINAL_JARVIS_GIT_SHA=$git_sha cargo build --release --locked --target "$target"
+  release_dir=target/$target/release
+else
+  TERMINAL_JARVIS_GIT_SHA=$git_sha cargo build --release --locked
+  release_dir=target/release
+fi
 
 dist=$out_root/$version/$platform
 stage=$dist/package/$name-$version-$platform
@@ -67,13 +85,13 @@ formula_dir=$dist/homebrew/Formula
 rm -rf "$dist"
 mkdir -p "$stage/bin" "$npm_stage/bin" "$formula_dir"
 
-cp target/release/$name "$stage/bin/$name"
+cp "$release_dir/$binary_name" "$stage/bin/$binary_name"
 cp README.md LICENSE CHANGELOG.md "$stage/"
 cp -R harnesses "$stage/"
-chmod +x "$stage/bin/$name"
+chmod +x "$stage/bin/$binary_name"
 
 (cd "$dist/package" && tar -czf "../$archive" "$name-$version-$platform")
-(cd "$dist" && sha256_file "$archive" >"$archive.sha256")
+(cd "$dist" && sha256_file "$archive" | sed 's/ \*/  /' >"$archive.sha256")
 sha=$(cut -d ' ' -f 1 "$dist/$archive.sha256")
 
 cp npm/terminal-jarvis/package.json "$npm_stage/"
@@ -113,21 +131,30 @@ scripts/check-distribution-payloads.sh --npm-stage "$npm_stage"
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 tar -xzf "$dist/$archive" -C "$tmp"
-expected=$(find harnesses -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
-actual=$("$tmp/$name-$version-$platform/bin/$name" list | wc -l | tr -d ' ')
-test "$actual" = "$expected" || fail "archive smoke listed $actual of $expected harnesses"
+test -x "$tmp/$name-$version-$platform/bin/$binary_name" ||
+  fail "archive missing executable bin/$binary_name"
+test -d "$tmp/$name-$version-$platform/harnesses" ||
+  fail "archive missing harnesses"
 
-if command -v node >/dev/null 2>&1; then
-  npm_stage_abs=$(cd "$npm_stage" && pwd)
-  TERMINAL_JARVIS_BIN="$stage/bin/$name" TERMINAL_JARVIS_CATALOG="$stage/harnesses" \
-    node "$npm_stage_abs/bin/terminal-jarvis" list >/dev/null
+if test "$target" = "$host_target"; then
+  expected=$(find harnesses -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+  actual=$("$tmp/$name-$version-$platform/bin/$binary_name" list | wc -l | tr -d ' ')
+  test "$actual" = "$expected" || fail "archive smoke listed $actual of $expected harnesses"
+
+  if command -v node >/dev/null 2>&1; then
+    npm_stage_abs=$(cd "$npm_stage" && pwd)
+    TERMINAL_JARVIS_BIN="$stage/bin/$binary_name" TERMINAL_JARVIS_CATALOG="$stage/harnesses" \
+      node "$npm_stage_abs/bin/terminal-jarvis" list >/dev/null
+  fi
+
+  scripts/integration-hardening.sh \
+    --binary "$stage/bin/$binary_name" \
+    --catalog "$stage/harnesses" \
+    --npm-wrapper "$npm_stage/bin/terminal-jarvis" \
+    --homebrew-formula "$formula_dir/terminal-jarvis.rb"
+else
+  echo "package-release: skipped execution smoke for cross target $target on $host_target"
 fi
-
-scripts/integration-hardening.sh \
-  --binary "$stage/bin/$name" \
-  --catalog "$stage/harnesses" \
-  --npm-wrapper "$npm_stage/bin/terminal-jarvis" \
-  --homebrew-formula "$formula_dir/terminal-jarvis.rb"
 
 echo "$dist/$archive"
 echo "$dist/$archive.sha256"

--- a/scripts/release.toml
+++ b/scripts/release.toml
@@ -1,2 +1,2 @@
 local_cd_dir = "local-cd"
-release_platforms = ["linux-x64-gnu", "macos-x64", "macos-arm64"]
+release_platforms = ["linux-x64-gnu", "linux-arm64-gnu", "macos-x64", "macos-arm64", "win32-x64"]


### PR DESCRIPTION
## Summary
- promote v0.1.11 release changes from develop to main
- adds Linux x64, Linux ARM64, macOS Intel, macOS ARM64, and Windows x64 release asset pipeline
- adds native Windows npm launcher support and stricter PATH-shadow install failure behavior
- lowers npm wrapper engine requirement to Node >=18.17

## Verification
- release PR #172 CI: Verify, Package Smoke, Security, Mutation all green
- Copilot review thread on #172 resolved
- Trivy PR-head scan on 6c37ab401b62bd97904ac7ba8bdb5d05bcfcc453: pass, zero findings
- manual develop CI run 28992565003 on merge commit 9d0c5fab57e1bb4ce67186f26065314dbd3cadfc: Verify, Package Smoke, Security, Mutation all green
