### PR TITLE
Fix generated formula binary install path

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -110,7 +110,7 @@ class TerminalJarvis < Formula
   license "MIT"
 
   def install
-    bin.install "bin/terminal-jarvis"
+    bin.install "bin/$binary_name" => "$name"
     pkgshare.install "harnesses"
   end
 


### PR DESCRIPTION
## Summary
- install the generated platform-specific packaged binary in the Homebrew formula
- rename the installed command back to the canonical terminal-jarvis executable

## Verification
- sh -n scripts/package-release.sh
- scripts/release-preflight.sh
- git diff --check
- scripts/package-release.sh build dist-formula-smoke
- GitNexus detect_changes: low risk